### PR TITLE
One solution to https://github.com/raspberrypi/firmware/issues/112

### DIFF
--- a/interface/khronos/common/linux/khrn_client_platform_linux.c
+++ b/interface/khronos/common/linux/khrn_client_platform_linux.c
@@ -115,6 +115,7 @@ void *platform_tls_get(PLATFORM_TLS_T tls)
 
 void *platform_tls_get_check(PLATFORM_TLS_T tls)
 {
+   if (!process_attached) tls = vcos_get_thread_current_key();
    return vcos_tls_get(tls);
 }
 

--- a/interface/vcos/pthreads/vcos_pthreads.c
+++ b/interface/vcos/pthreads/vcos_pthreads.c
@@ -135,6 +135,13 @@ static void _task_timer_expiration_routine(void *cxt)
    thread->orig_task_timer_expiration_routine = NULL;
 }
 
+/* Return thread_current_key to libraries like libEGL
+ */
+VCOS_TLS_KEY_T vcos_get_thread_current_key()
+{
+    return _vcos_thread_current_key;
+}
+
 VCOS_STATUS_T vcos_thread_create(VCOS_THREAD_T *thread,
                                  const char *name,
                                  VCOS_THREAD_ATTR_T *attrs,

--- a/interface/vcos/vcos_thread.h
+++ b/interface/vcos/vcos_thread.h
@@ -91,6 +91,10 @@ extern "C" {
   */
 VCOSPRE_ int VCOSPOST_ vcos_have_rtos(void);
 
+/** Return thread_current_key needed by libEGL
+  */
+VCOSPRE_ VCOS_TLS_KEY_T VCOSPOST_ vcos_get_thread_current_key();
+
 /** Create a thread. It must be cleaned up by calling vcos_thread_join().
   *
   * @param thread   Filled in on return with thread


### PR DESCRIPTION
It is probably a bug that client_tls was not set during eglGetDisplay.

This patch imitates the behavior that happens when you load libvcos.so before using thread-local storage in your program, like how node.js is doing. So it might not fix the actual bug. Works for GLESv2 at least. Can't check with node-openvg because it requires eglGetDisplay to be called before loading.

I don't know enough about the wrapping to do better yet.
