### PR TITLE
Test for the existence of execinfo.h

### DIFF
--- a/interface/vcos/glibc/vcos_backtrace.c
+++ b/interface/vcos/glibc/vcos_backtrace.c
@@ -26,7 +26,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <interface/vcos/vcos.h>
-#ifdef __linux__
+#ifdef HAVE_CMAKE_CONFIG
+#include "cmake_config.h"
+#endif
+#ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
 #endif
 #include <stdio.h>
@@ -35,7 +38,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void vcos_backtrace_self(void)
 {
-#ifdef __linux__
+#ifdef HAVE_EXECINFO_H
    void *stack[64];
    int depth = backtrace(stack, sizeof(stack)/sizeof(stack[0]));
    char **names = backtrace_symbols(stack, depth);

--- a/makefiles/cmake/arm-linux.cmake
+++ b/makefiles/cmake/arm-linux.cmake
@@ -115,6 +115,10 @@ try_compile(HAVE_MTRACE
             ${CMAKE_SOURCE_DIR}/makefiles/cmake/srcs/test-mtrace.c
             OUTPUT_VARIABLE foo)
 
+# test for existence of execinfo.h header
+include(CheckIncludeFile)
+check_include_file(execinfo.h HAVE_EXECINFO_H)
+
 add_definitions(-DHAVE_CMAKE_CONFIG)
 configure_file (
     "makefiles/cmake/cmake_config.h.in"

--- a/makefiles/cmake/cmake_config.h.in
+++ b/makefiles/cmake/cmake_config.h.in
@@ -8,5 +8,8 @@
 /** Do we have support for GLIBC mtrace() ? */
 #cmakedefine                    HAVE_MTRACE
 
+/** Do we have the execinfo.h include file ? */
+#cmakedefine                    HAVE_EXECINFO_H
+
 #endif
 


### PR DESCRIPTION
Previous code assumed that on Linux the execinfo.h functions are always available, which is a glibc extension.
This change fixes building the library under buildroot, which uses uClibc by default
