### PR TITLE
Load eglIntOpenMAXILDoneMarker() explicitely via dlsym()  instead of having a stub in libEGL and libbcm_host

### DIFF
--- a/host_applications/linux/libs/bcm_host/bcm_host.c
+++ b/host_applications/linux/libs/bcm_host/bcm_host.c
@@ -133,11 +133,6 @@ void bcm_host_deinit(void)
 }
 
 // Fix linking problems. These are referenced by libs, but shouldn't be called
-int eglIntOpenMAXILDoneMarker (void* component_handle, void * egl_image)
-{
-   vcos_assert(0);
-   return 0;
-}
 void wfc_stream_await_buffer(void * stream)
 {
    vcos_assert(0);

--- a/interface/vcos/pthreads/vcos_platform.h
+++ b/interface/vcos/pthreads/vcos_platform.h
@@ -57,6 +57,7 @@ extern "C" {
 #include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <dlfcn.h>
 
 
 #define VCOS_HAVE_RTOS         1
@@ -722,6 +723,11 @@ char *vcos_strdup(const char *str)
 }
 
 typedef void (*VCOS_ISR_HANDLER_T)(VCOS_UNSIGNED vecnum);
+
+#define VCOS_DL_LAZY RTLD_LAZY
+#define VCOS_DL_NOW  RTLD_NOW
+#define VCOS_DL_LOCAL  RTLD_LOCAL
+#define VCOS_DL_GLOBAL  RTLD_GLOBAL
 
 #ifdef __cplusplus
 }

--- a/interface/vcos/vcos_dlfcn.h
+++ b/interface/vcos/vcos_dlfcn.h
@@ -39,9 +39,6 @@ VCOS - abstraction over dynamic library opening
 extern "C" {
 #endif
 
-#define VCOS_DL_LAZY 1
-#define VCOS_DL_NOW  2
-
 /**
  * \file
  *
@@ -51,7 +48,7 @@ extern "C" {
 /** Open a dynamic library.
   *
   * @param name  name of the library
-  * @param mode  Load lazily or immediately (VCOS_DL_LAZY, VCOS_DL_NOW).
+  * @param mode  Load lazily or immediately (VCOS_DL_LAZY, VCOS_DL_NOW, VCOS_DL_LOCAL, VCOS_DL_GLOBAL).
   *
   * @return A handle for use in subsequent calls.
   */


### PR DESCRIPTION
...ng a stub in libEGL and libbcm_host

This fixes linking problems caused by "wrong" linking order and especially
makes this work reliable if libopenmaxil is loaded via dlopen().

https://github.com/raspberrypi/firmware/issues/158
