### PR TITLE
Symbian Support

### DIFF
--- a/interface/vchiq_arm/vchiq_ioctl.h
+++ b/interface/vchiq_arm/vchiq_ioctl.h
@@ -28,7 +28,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef VCHIQ_IOCTLS_H
 #define VCHIQ_IOCTLS_H
 
+#ifndef __SYMBIAN32__
 #include <linux/ioctl.h>
+#endif
 #include "vchiq_if.h"
 
 #define VCHIQ_IOC_MAGIC 0xc4

--- a/interface/vcos/pthreads/vcos_pthreads.c
+++ b/interface/vcos/pthreads/vcos_pthreads.c
@@ -580,7 +580,11 @@ const char ** vcos_get_argv(void)
  */
 uint32_t _vcos_get_ticks_per_second(void)
 {
+#ifdef __SYMBIAN32__
+   return 1;
+#else
    return HZ;
+#endif
 }
 
 VCOS_STATUS_T vcos_once(VCOS_ONCE_T *once_control,

--- a/interface/vmcs_host/linux/vcfilesys.c
+++ b/interface/vmcs_host/linux/vcfilesys.c
@@ -42,14 +42,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ctype.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#ifdef __SYMBIAN32__
+#include <sys/syslimits.h>
+#else
 #include <sys/statfs.h>
+#endif
 #include <fcntl.h>
 #include <errno.h>
 #include <assert.h>
 #include <ctype.h>
 #include <limits.h>
 
-#if !defined(ANDROID) && !defined( __USE_FILE_OFFSET64 )
+#if !defined(__SYMBIAN32__) && !defined(ANDROID) && !defined( __USE_FILE_OFFSET64 )
 #error   "__USE_FILE_OFFSET64 isn't defined"
 #endif
 
@@ -595,6 +599,9 @@ int64_t vc_hostfs_freespace64(const char *inPath)
 {
    char *path = strdup( inPath );
    int64_t ret;
+#ifdef __SYMBIAN32__
+   ret = 1024 * 1024 * 32; // HACK: 32MB
+#else
    struct statfs fsStat;
 
    // Replace all '\' with '/'
@@ -614,6 +621,7 @@ int64_t vc_hostfs_freespace64(const char *inPath)
    DEBUG_MINOR( "vc_hostfs_freespace64 for '%s' returning %lld", path, ret );
 
    free( path );
+#endif
    return ret;
 }
 
@@ -997,6 +1005,9 @@ int64_t vc_hostfs_totalspace64(const char *inPath)
 {
    char *path = strdup( inPath );
    int64_t ret = -1;
+#ifdef __SYMBIAN32__
+   ret = 1024 * 1024 * 128; // HACK: 128MB
+#else
    struct statfs fsStat;
 
    // Replace all '\' with '/'
@@ -1020,6 +1031,7 @@ int64_t vc_hostfs_totalspace64(const char *inPath)
 
    if (path)
       free( path );
+#endif
    return ret;
 }
 

--- a/interface/vmcs_host/vc_vchi_bufman.h
+++ b/interface/vmcs_host/vc_vchi_bufman.h
@@ -33,7 +33,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __SYMBIAN32__
 #include "interface/vmcs_host/vc_vchi_bufman_defs.h"
 typedef uint32_t DISPMANX_RESOURCE_HANDLE_T;
+#ifdef __cplusplus
 namespace BufManX {
+#endif
 #else
 #include "interface/vmcs_host/vc_dispmanx.h"
 #include "interface/vmcs_host/vc_vchi_bufman_defs.h"
@@ -110,7 +112,9 @@ VCHPRE_ void VCHPOST_ vc_bufmanx_push_multi_stream ( BUFMANX_HANDLE_T *xh, const
 VCHPRE_ VC_IMAGE_TYPE_T VCHPOST_ vc_bufmanx_get_vc_image_type(buf_frame_type_t bm_type);
 
 #ifdef __SYMBIAN32__
+#ifdef __cplusplus
 } // namespace BufManX
+#endif
 #endif
 
 #endif /* VC_VCHI_BUFMAN_H */

--- a/interface/vmcs_host/vc_vchi_bufman_defs.h
+++ b/interface/vmcs_host/vc_vchi_bufman_defs.h
@@ -30,7 +30,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef __SYMBIAN32__
 typedef uint32_t DISPMANX_RESOURCE_HANDLE_T;
+#ifdef __cplusplus
 namespace BufManX {
+#endif
 #else
 #include "interface/vmcs_host/vc_dispmanx.h"
 #endif
@@ -130,7 +132,9 @@ enum {
 };
 
 #ifdef __SYMBIAN32__
+#ifdef __cplusplus
 } // namespace BufManX
+#endif
 #endif
 
 #endif /* VC_VCHI_BUFMAN_DEFS_H */


### PR DESCRIPTION
## Changes

Symbian doesn't have 'HZ' defined in sys/param.h. Use 1 instead.
Symbian doesn't have linux headers.
Symbian doesn't have fsStat. Let's hack around that for now. 32MB free space, 128MB total space. This will never hit anyway.
Protected namespace with __cplusplus.

Confirmed working on Nokia N8 (VideoCore III) and Nokia 808 (VideoCore IV).

There is no vchiq on Symbian. Uses its own messaging system.
## How to

To test on Symbian with an existing Qt project
Add the following to your project.pro file:

```
BCM_HEADERS = C:/Users/Me/Desktop/videocore/userland
INCLUDEPATH += $${BCM_HEADERS}/ \
    $${BCM_HEADERS}/interface/vchi/ \
    $${BCM_HEADERS}/interface/vcos/pthreads/
LIBS += -lvcos -lvchi -lvcstreamio
DEFINES += USE_VCHIQ_ARM
```

where BCM_HEADERS is where you have cloned this git.

Add the following to your main.cpp file:

``` C++
#include "vchi.h"
int main() {
...
    vcos_init();
...
}
```
