### PR TITLE
Re-enabled ISO setting

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -765,7 +765,7 @@ int raspicamcontrol_set_all_parameters(MMAL_COMPONENT_T *camera, const RASPICAM_
    result += raspicamcontrol_set_sharpness(camera, params->sharpness);
    result += raspicamcontrol_set_contrast(camera, params->contrast);
    result += raspicamcontrol_set_brightness(camera, params->brightness);
-   //result += raspicamcontrol_set_ISO(camera, params->ISO); TODO Not working for some reason
+   result += raspicamcontrol_set_ISO(camera, params->ISO);
    result += raspicamcontrol_set_video_stabilisation(camera, params->videoStabilisation);
    result += raspicamcontrol_set_exposure_compensation(camera, params->exposureCompensation);
    result += raspicamcontrol_set_exposure_mode(camera, params->exposureMode);


### PR DESCRIPTION
Tests show (in EXIF data of test jpegs) you can set between 100 and 800 OK. But not sure how to test it has actually used that value!
