### PR TITLE
Fix of issue #39 for RaspiCam apps

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -61,7 +61,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/stat.h>
 #include <sys/file.h>
 
-#define VERSION_STRING "v1.2"
+#define VERSION_STRING "v1.3.4"
 
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -59,7 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/stat.h>
 #include <sys/file.h>
 
-#define VERSION_STRING "v1.3"
+#define VERSION_STRING "v1.3.2"
 
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -60,7 +60,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/stat.h>
 #include <sys/file.h>
 
-#define VERSION_STRING "v1.2"
+#define VERSION_STRING "v1.3.3"
 
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"


### PR DESCRIPTION
Fixes issues caused when invoking multiple instances of RaspiCam apps.
Prevents the same user from invoking a second instance by checking the lock on a file stored in the user's home directory.
I realise this isn't ideal as it does not prevent multiple users invoking simultaneous instances, or prevent simultaneous access attempts to the camera though MMAL, but I imagine will fix the issue for the majority of users.
