### PR TITLE
Update RaspiStill.c

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1015,7 +1015,7 @@ static void add_exif_tags(RASPISTILL_STATE *state)
    timeinfo = localtime(&rawtime);
 
    snprintf(time_buf, sizeof(time_buf),
-            "%04d:%02d:%02d:%02d:%02d:%02d",
+            "%04d:%02d:%02d %02d:%02d:%02d",
             timeinfo->tm_year+1900,
             timeinfo->tm_mon+1,
             timeinfo->tm_mday,


### PR DESCRIPTION
Date and time of EXIF DateTime fields is now separated by a space instead of a colon, in accordance with EXIF 2.1.
