### PR TITLE
Userland #80 - fix for exposure setting

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -738,7 +738,7 @@ void raspicamcontrol_set_defaults(RASPICAM_CAMERA_PARAMETERS *params)
    params->contrast = 0;
    params->brightness = 50;
    params->saturation = 0;
-   params->ISO = 400;
+   params->ISO = 0;                    // 0 = auto
    params->videoStabilisation = 0;
    params->exposureCompensation = 0;
    params->exposureMode = MMAL_PARAM_EXPOSUREMODE_AUTO;


### PR DESCRIPTION
Fix for bad exposure setting - set ISO to auto on startup, rather than 400, which was breaking exposure in odd ways
