### PR TITLE
Update RaspiStill.c to fix argument validation error message

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -591,6 +591,11 @@ static int parse_cmdline(int argc, const char **argv, RASPISTILL_STATE *state)
          break;
       }
       }
+      if (!valid)
+      {
+      	// no need to check all arg if one is invalid
+         break;
+      }
    }
 
    if (!valid)


### PR DESCRIPTION
fix argument validation error message
The error essage was about the last argument instead of being about the erroneous argument:
When using
raspistill -test.jpg -v instead of 
raspistill -o test.jpg -v
I got an error message saying -v was an invalid parameter.
