### PR TITLE
Fix "Invalid command line option" message - invalid arg index was used

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -638,7 +638,7 @@ static int parse_cmdline(int argc, const char **argv, RASPISTILL_STATE *state)
 
    if (!valid)
    {
-      fprintf(stderr, "Invalid command line option (%s)\n", argv[i]);
+      fprintf(stderr, "Invalid command line option (%s)\n", argv[i-1]);
       return 1;
    }
 

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -328,7 +328,7 @@ static int parse_cmdline(int argc, const char **argv, RASPISTILLYUV_STATE *state
 
    if (!valid)
    {
-      fprintf(stderr, "Invalid command line option (%s)\n", argv[i]);
+      fprintf(stderr, "Invalid command line option (%s)\n", argv[i-1]);
       return 1;
    }
 

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -642,7 +642,7 @@ static int parse_cmdline(int argc, const char **argv, RASPIVID_STATE *state)
 
    if (!valid)
    {
-      fprintf(stderr, "Invalid command line option (%s)\n", argv[i]);
+      fprintf(stderr, "Invalid command line option (%s)\n", argv[i-1]);
       return 1;
    }
 


### PR DESCRIPTION
Change
`$ raspistill -abc
Invalid command line option (null)`
into 
`$ raspistill -abc
Invalid command line option (-abc)`
