### PR TITLE
Wrong sign in if condition

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1354,7 +1354,7 @@ static int wait_for_next_frame(RASPISTILL_STATE *state, int *frame)
          if (this_delay_ms < 0)
          {
             // We are already past the next exposure time
-            if (-this_delay_ms < -state->timelapse/2)
+            if (-this_delay_ms < state->timelapse/2)
             {
                // Less than a half frame late, take a frame and hope to catch up next time
                next_frame_ms += state->timelapse;


### PR DESCRIPTION
if (-this_delay_ms < -state->timelapse/2), -this_delay_ms is always positive,
and -state->timelapse/2 is negative, so this if is never true.  The if
condition should be if (-this_delay_ms < state->timelapse/2).