### PR TITLE
Add cmake rules to install mmal headerfiles to /opt/vc/include/interface...

### DIFF
--- a/interface/mmal/CMakeLists.txt
+++ b/interface/mmal/CMakeLists.txt
@@ -18,3 +18,25 @@ target_link_libraries(mmal mmal_core mmal_util mmal_vc_client vcos)
 endif(BUILD_MMAL_COMPONENTS)
 
 install(TARGETS mmal DESTINATION lib)
+install(FILES
+   mmal.h
+   mmal_buffer.h
+   mmal_clock.h
+   mmal_common.h
+   mmal_component.h
+   mmal_encodings.h
+   mmal_events.h
+   mmal_format.h
+   mmal_logging.h
+   mmal_metadata.h
+   mmal_parameters.h
+   mmal_parameters_audio.h
+   mmal_parameters_camera.h
+   mmal_parameters_clock.h
+   mmal_parameters_common.h
+   mmal_parameters_video.h
+   mmal_pool.h mmal_port.h
+   mmal_queue.h
+   mmal_types.h
+   DESTINATION include/interface/mmal
+)

--- a/interface/mmal/core/CMakeLists.txt
+++ b/interface/mmal/core/CMakeLists.txt
@@ -14,3 +14,11 @@ add_library (mmal_core SHARED
 target_link_libraries (mmal_core vcos)
 
 install(TARGETS mmal_core DESTINATION lib)
+install(FILES
+   mmal_buffer_private.h
+   mmal_clock_private.h
+   mmal_component_private.h
+   mmal_core_private.h
+   mmal_port_private.h
+   DESTINATION include/interface/mmal/core
+)

--- a/interface/mmal/util/CMakeLists.txt
+++ b/interface/mmal/util/CMakeLists.txt
@@ -13,3 +13,16 @@ add_library (mmal_util SHARED
 target_link_libraries (mmal_util vcos)
 
 install(TARGETS mmal_util DESTINATION lib)
+install(FILES
+   mmal_component_wrapper.h
+   mmal_connection.h
+   mmal_default_components.h
+   mmal_graph.h
+   mmal_il.h
+   mmal_list.h
+   mmal_param_convert.h
+   mmal_util.h
+   mmal_util_params.h
+   mmal_util_rational.h
+   DESTINATION include/interface/mmal/util
+)

--- a/interface/mmal/vc/CMakeLists.txt
+++ b/interface/mmal/vc/CMakeLists.txt
@@ -8,3 +8,13 @@ install(TARGETS mmal_vc_diag RUNTIME DESTINATION bin)
 endif(BUILD_MMAL_APPS)
 
 install(TARGETS mmal_vc_client DESTINATION lib)
+install(FILES
+   mmal_vc_api.h
+   mmal_vc_api_drm.h
+   mmal_vc_client_priv.h
+   mmal_vc_msgnames.h
+   mmal_vc_msgs.h
+   mmal_vc_opaque_alloc.h
+   mmal_vc_shm.h
+   DESTINATION include/interface/mmal/vc
+)


### PR DESCRIPTION
These patches to the CMakeLists.txt files in interface/mmal\* also install the mmal header files to include/interface/mmal/*. They're needed to compile and link to lib/mmal.so family.

Tested on a native build, hence the /opt/vc prefix in the commit message.

Maybe related: http://www.raspberrypi.org/phpBB3/viewtopic.php?t=45328&p=358808
