### PR TITLE
Make constant QP mode actually have constant QP

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1218,17 +1218,26 @@ static MMAL_STATUS_T create_encoder_component(RASPIVID_STATE *state)
       status = mmal_port_parameter_set(encoder_output, &param.hdr);
       if (status != MMAL_SUCCESS)
       {
-         vcos_log_error("Unable to set QP");
+         vcos_log_error("Unable to set initial QP");
          goto error;
       }
 
-      MMAL_PARAMETER_UINT32_T param2 = {{ MMAL_PARAMETER_VIDEO_ENCODE_QP_P, sizeof(param)}, state->quantisationParameter+6};
+      MMAL_PARAMETER_UINT32_T param2 = {{ MMAL_PARAMETER_VIDEO_ENCODE_MIN_QUANT, sizeof(param)}, state->quantisationParameter};
       status = mmal_port_parameter_set(encoder_output, &param2.hdr);
       if (status != MMAL_SUCCESS)
       {
-         vcos_log_error("Unable to set QP");
+         vcos_log_error("Unable to set min QP");
          goto error;
       }
+
+      MMAL_PARAMETER_UINT32_T param3 = {{ MMAL_PARAMETER_VIDEO_ENCODE_MAX_QUANT, sizeof(param)}, state->quantisationParameter};
+      status = mmal_port_parameter_set(encoder_output, &param3.hdr);
+      if (status != MMAL_SUCCESS)
+      {
+         vcos_log_error("Unable to set max QP");
+         goto error;
+      }
+
    }
 
    {


### PR DESCRIPTION
Before this patch, recording with raspivid -t 10000 --qp NN (all default settings otherwise) the actual qp for the first 10 frames is:
--qp 20: 20, 20, 20, 22, 24, 22, 21, 20, 20, 21, 22, ...
--qp 30: 30, 30, 30, 28, 30, 28, 26, 24, 22, 20, 22, ...
and then 22-23 for most subsequent frames.  This is as seen in h264bitstream's h264_analyze output.  Also, the file sizes are the same +/- a few percent (this is the same static scene).

With this patch, reported qp is exactly as set for all frames and resulting file sizes are 35MB vs 1MB.
