### PR TITLE
RaspiVid.c: actually use the return value of sigwait.

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1502,7 +1502,10 @@ static int wait_for_next_change(RASPIVID_STATE *state)
       if (state->verbose && result != 0)
          fprintf(stderr, "Bad signal received - error %d\n", errno);
 
-      return keep_running;
+      if (result == 0)
+         return 0;
+      else
+         return keep_running;
    }
 
    } // switch


### PR DESCRIPTION
In wait_for_next_change, keep_running was always returned when WAIT_METHOD_SIGNAL was the selected wait method, even though it received the correct SIGUSR1 signal.
