### PR TITLE
#178 CMakelists.txt: Add '--no-as-needed' linker flag to ensure all specified...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(host_support/include)
 # Global compiler flags
 if(CMAKE_COMPILER_IS_GNUCC)
    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-multichar -Wall -Wno-unused-but-set-variable")
+   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
 endif()
 
 add_definitions(-D_REENTRANT)


### PR DESCRIPTION
... shared libraries are linked against applications (e.g. raspivid)

libmmal_vc_client.so makes use of **attribute**(constructor) to ensure that supplier components (e.g. camera) are loaded when the static library is loaded.

raspivid, and possibly other applications, link against libmmal_vc_client.so, causing the ctor to execute, but there is no needed dependency.

Some build environments (e.g. Yocto/OpenEmbedded) pass the '--no-as-needed' linker flag which removes the dependency on libmmal_vc_client and thus components are not registered.

In this situation raspivid then gives an error of the form

root@raspberrypi:~# raspivid -o test
mmal: mmal_component_create_core: could not find component 'vc.ril.camera'
mmal: Failed to create camera component
mmal: main: Failed to create camera component
mmal: Failed to run camera app. Please check for firmware updates

For further details see: https://lists.yoctoproject.org/pipermail/yocto/2014-June/019933.html

Signed-off-by: Alex J Lennon ajlennon@dynamicdevices.co.uk
