### PR TITLE
Use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/containers/CMakeLists.txt
+++ b/containers/CMakeLists.txt
@@ -55,7 +55,7 @@ endif (DEFINED MSVC)
 set(extra_net_SRCS net_sockets_win32.c net_sockets_win32.h net_sockets_null.c)
 add_custom_target(containers_net_extra ALL
     COMMAND touch ${extra_net_SRCS}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/containers/net)
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/containers/net)
 
 # Packetizers library
 set(packetizers_SRCS ${packetizers_SRCS} ${SOURCE_DIR}/core/packetizers.c)

--- a/containers/test/CMakeLists.txt
+++ b/containers/test/CMakeLists.txt
@@ -22,7 +22,7 @@ endif (WIN32)
 set(extra_test_SRCS nb_io_win32.c autotest.cpp crc_32.c)
 add_custom_target(containers_test_extra
     COMMAND touch ${extra_test_SRCS}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/containers/test)
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/containers/test)
 add_dependencies(containers_test containers_test_extra)
 
 # Generate net test applications

--- a/host_applications/android/apps/vidtex/CMakeLists.txt
+++ b/host_applications/android/apps/vidtex/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 SET(COMPILE_DEFINITIONS -Werror -Wall)
-include_directories(${CMAKE_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
+include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
 
 set (VIDTEX_SOURCES
    main.cpp

--- a/host_applications/linux/apps/hello_pi/CMakeLists.txt
+++ b/host_applications/linux/apps/hello_pi/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(BUILD_FONT FALSE)
 
-include_directories(${CMAKE_SOURCE_DIR})
-include_directories(${CMAKE_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
+include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libs/ilclient)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libs/vgfont)
 

--- a/host_applications/linux/apps/raspicam/CMakeLists.txt
+++ b/host_applications/linux/apps/raspicam/CMakeLists.txt
@@ -3,8 +3,8 @@
 
 SET(COMPILE_DEFINITIONS -Werror)
 
-include_directories(${CMAKE_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
-include_directories(${CMAKE_SOURCE_DIR}/host_applications/linux/apps/raspicam/)
+include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
+include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/apps/raspicam/)
 
 set (GL_SCENE_SOURCES
    gl_scenes/models.c

--- a/interface/mmal/components/CMakeLists.txt
+++ b/interface/mmal/components/CMakeLists.txt
@@ -23,7 +23,7 @@ set(extra_components_SRCS avcodec_video_decoder.c avcodec_audio_decoder.c
 
 add_custom_target(mmal_components_extra ALL
     COMMAND touch ${extra_components_SRCS}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/interface/mmal/components)
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/interface/mmal/components)
 
 set(container_libs ${container_libs} containers)
 

--- a/makefiles/cmake/arm-linux.cmake
+++ b/makefiles/cmake/arm-linux.cmake
@@ -115,7 +115,7 @@ add_definitions(-D_LARGEFILE64_SOURCE)
 # test for glibc malloc debugging extensions
 try_compile(HAVE_MTRACE
             ${CMAKE_BINARY_DIR}
-            ${CMAKE_SOURCE_DIR}/makefiles/cmake/srcs/test-mtrace.c
+            ${PROJECT_SOURCE_DIR}/makefiles/cmake/srcs/test-mtrace.c
             OUTPUT_VARIABLE foo)
 
 # test for existence of execinfo.h header


### PR DESCRIPTION
This way, the userland top-level CMakeLists.txt can be included with
add_subdirectory() from another project, e.g., as a submodule.
