### PR TITLE
Zero copy, and buildme change for Pi2

### DIFF
--- a/buildme
+++ b/buildme
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-if [ "armv6l" = `arch` ]; then
+if [ "armv6l" = `arch` ] || [ "armv7l" = `arch` ]; then
 	# Native compile on the Raspberry Pi
 	mkdir -p build/raspberry/release
 	pushd build/raspberry/release
 	cmake -DCMAKE_BUILD_TYPE=Release ../../..
-	make
+	if [ "armv6l" = `arch` ]; then
+		make
+	else
+		make -j4
+	fi
 	if [ "$1" != "" ]; then
 	 sudo make install DESTDIR=$1
 	else

--- a/interface/mmal/vc/CMakeLists.txt
+++ b/interface/mmal/vc/CMakeLists.txt
@@ -1,12 +1,9 @@
-# MMAL can use VCSM to allow zero copy for ARM accessible buffers.
-# This is not enabled by default right now because VCSM on RPI is still
-# experimental.
-# add_definitions(-DENABLE_MMAL_VCSM)
+add_definitions(-DENABLE_MMAL_VCSM)
 
 add_library(mmal_vc_client ${LIBRARY_TYPE} mmal_vc_client.c mmal_vc_shm.c mmal_vc_api.c mmal_vc_opaque_alloc.c mmal_vc_msgnames.c mmal_vc_api_drm.c)
-target_link_libraries(mmal_vc_client vchiq_arm vcos)
+#target_link_libraries(mmal_vc_client vchiq_arm vcos)
 
-# target_link_libraries(mmal_vc_client vchiq_arm vcos vcsm)
+target_link_libraries(mmal_vc_client vchiq_arm vcos vcsm)
 
 if(BUILD_MMAL_APPS)
 add_executable(mmal_vc_diag mmal_vc_diag.c)


### PR DESCRIPTION
As per commit text.
- buildme dropped into the cross compile path when building on Pi2, so didn't install.
- enable zero copy within MMAL.