### PR TITLE
Added "all" target to hello_fft/makefile

### DIFF
--- a/host_applications/linux/apps/hello_pi/hello_fft/makefile
+++ b/host_applications/linux/apps/hello_pi/hello_fft/makefile
@@ -24,6 +24,8 @@ H2D = gpu_fft.h mailbox.h gpu_fft_trans.h hello_fft_2d_bitmap.h
 
 F = -lrt -lm -ldl
 
+all:	hello_fft.bin hello_fft_2d.bin
+
 hello_fft.bin:	$(S) $(C1D) $(H1D)
 	gcc -o hello_fft.bin $(F) $(C1D)
 


### PR DESCRIPTION
Same patch as https://github.com/raspberrypi/firmware/pull/422 for the firmware repository: The reason, why I added a new target "all" is that without it, the script /opt/vc/src/hello_pi/rebuild.sh only builds hello_fft.bin, but not hello_fft_2d.bin.