### PR TITLE
Proposing VC_DISPLAY env variable

### DIFF
--- a/interface/vmcs_host/vc_vchi_dispmanx.c
+++ b/interface/vmcs_host/vc_vchi_dispmanx.c
@@ -25,6 +25,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <string.h>
+#include <stdlib.h>
 
 #include "vchost_config.h"
 #include "vchost.h"
@@ -510,6 +511,13 @@ VCHPRE_ int VCHPOST_ vc_dispmanx_resource_write_data_handle( DISPMANX_RESOURCE_H
  ***********************************************************/
 VCHPRE_ DISPMANX_DISPLAY_HANDLE_T VCHPOST_ vc_dispmanx_display_open( uint32_t device ) {
    uint32_t display_handle;
+   char *env = getenv("VC_DISPLAY");
+
+   if (device == 0 && env)
+   {
+      device = atoi(env);
+   }
+
    device = VC_HTOV32(device);
    display_handle = dispmanx_get_handle(EDispmanDisplayOpen,
                                                  &device, sizeof(device));


### PR DESCRIPTION
It would be nice if there was a standardized way to instruct applications to use a certain display, without having to patch the application's source code.
Proposing a VC_DISPLAY environment variable for this purpose.

To force display on HDMI one could then execute:

```
VC_DISPLAY=5 any-egl-application
```

Similar to the standardized DISPLAY variable used by X11 applications.