### PR TITLE
Fix error when building against musl libc.

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -106,8 +106,6 @@ const int ABORT_INTERVAL = 100; // ms
 /// Run/record forever
 #define WAIT_METHOD_FOREVER        4
 
-extern FILE *stderr, *stdout;
-
 int mmal_status_to_int(MMAL_STATUS_T status);
 static void signal_handler(int signal_number);
 


### PR DESCRIPTION
When building with a musl based toolchain, the build fails with the
following message:

host_applications/linux/apps/raspicam/CMakeFiles/raspividyuv.dir/RaspiVidYUV.c.o
In file included from
error: conflicting type qualifiers for ‘stderr’
extern FILE *stderr, *stdout;
^

That's because musl defines stderr and stdout as a const pointer:

extern FILE *const stdin;
extern FILE *const stdout;
extern FILE *const stderr;

And the application (RaspiVidYUV.c) don't:

extern FILE *stderr, *stdout;

Since this declaration already comes in on the header (stdio.h),
there is no need to add an extern declaration, so removes it to
fix the build problem with the musl libc.

Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>