### PR TITLE
GCC5 fixes

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -350,7 +350,7 @@ static void dump_status(RASPISTILL_STATE *state)
    for (i=0;i<next_frame_description_size;i++)
    {
       if (state->frameNextMethod == next_frame_description[i].nextFrameMethod)
-         fprintf(stderr, next_frame_description[i].description);
+         fprintf(stderr, "%s", next_frame_description[i].description);
    }
    fprintf(stderr, "\n\n");
 

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -267,7 +267,7 @@ static void dump_status(RASPISTILLYUV_STATE *state)
    for (i=0;i<next_frame_description_size;i++)
    {
       if (state->frameNextMethod == next_frame_description[i].nextFrameMethod)
-         fprintf(stderr, next_frame_description[i].description);
+         fprintf(stderr, "%s", next_frame_description[i].description);
    }
    fprintf(stderr, "\n\n");
 

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -400,7 +400,7 @@ static void dump_status(RASPIVID_STATE *state)
    for (i=0;i<wait_method_description_size;i++)
    {
       if (state->waitMethod == wait_method_description[i].nextWaitMethod)
-         fprintf(stderr, wait_method_description[i].description);
+         fprintf(stderr, "%s", wait_method_description[i].description);
    }
    fprintf(stderr, "\nInitial state '%s'\n", raspicli_unmap_xref(state->bCapturing, initial_map, initial_map_size));
    fprintf(stderr, "\n\n");

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -300,7 +300,7 @@ static void dump_status(RASPIVIDYUV_STATE *state)
    for (i=0;i<wait_method_description_size;i++)
    {
       if (state->waitMethod == wait_method_description[i].nextWaitMethod)
-         fprintf(stderr, wait_method_description[i].description);
+         fprintf(stderr, "%s", wait_method_description[i].description);
    }
    fprintf(stderr, "\nInitial state '%s'\n", raspicli_unmap_xref(state->bCapturing, initial_map, initial_map_size));
    fprintf(stderr, "\n\n");

--- a/host_applications/linux/apps/raspicam/gl_scenes/models.c
+++ b/host_applications/linux/apps/raspicam/gl_scenes/models.c
@@ -255,7 +255,7 @@ static int load_wavefront_obj(const char *modelname, WAVEFRONT_MODEL_T *model, s
                m->material_index[m->num_materials] = (pf-qf)/3;
                m->num_materials++;
             }
-         } else { printf(s); vc_assert(0); }
+         } else { printf("%s", s); vc_assert(0); }
          break;
       case 'g': vc_assert(strncmp(s, "g ", sizeof "g "-1)==0); break;
       case 's': vc_assert(strncmp(s, "s ", sizeof "s "-1)==0); break;
@@ -305,7 +305,7 @@ static int load_wavefront_obj(const char *modelname, WAVEFRONT_MODEL_T *model, s
                *pf++ = pp[3*i+0]; *pf++ = pp[3*i+1]; *pf++ = pp[3*i+2];
                *pf++ = pp[3*(i+1)+0]; *pf++ = pp[3*(i+1)+1]; *pf++ = pp[3*(i+1)+2];
             }
-         } else { printf(s); vc_assert(0); }
+         } else { printf("%s", s); vc_assert(0); }
          break;
       default: 
          printf("%02x %02x %s", s[0], s[1], s); vc_assert(0); break;

--- a/host_applications/linux/apps/smem/smem.c
+++ b/host_applications/linux/apps/smem/smem.c
@@ -192,7 +192,7 @@ int main( int argc, char **argv )
    int  opt;
    int  opt_alloc = 0;
    int  opt_status = 0;
-   uint32_t alloc_size;
+   uint32_t alloc_size = 0;
    int  opt_pid = -1;
    VCSM_STATUS_T status_mode = VCSM_STATUS_NONE;
 


### PR DESCRIPTION
This is just a small patch That I have been using to build my userland deb files with gcc5, most of it is pretty safe and harmless, mostly printf (and friends) to fputs and such.

The inline declarations is the only one I'm not sure would be backwards compat and none of my build systems have gcc4.9 or are none GNUC to test on.

Be nice to get this accepted so I no longer have to patch my builds anymore.