### PR TITLE
RaspiStill: Fix compiler warnings

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -51,6 +51,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <string.h>
 #include <memory.h>
 #include <unistd.h>

--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -467,7 +467,7 @@ static int parse_cmdline(int argc, const char **argv, RASPISTILL_STATE *state)
          {
             //We use sprintf to append the frame number for timelapse mode
             //Ensure that any %<char> is either %% or %d.
-            char *percent = argv[i+1];
+            const char *percent = argv[i+1];
             while(valid && *percent && (percent=strchr(percent, '%')) != NULL)
             {
                int digits=0;


### PR DESCRIPTION
Fix RaspiStill compiler warnings:
- discards const qualifier
- implicit declaration of function isdigit
