### PR TITLE
Allow to override VMCS_INSTALL_PREFIX

### DIFF
--- a/makefiles/cmake/vmcs.cmake
+++ b/makefiles/cmake/vmcs.cmake
@@ -9,7 +9,7 @@ INCLUDE(CPack)
 # Where shall we install?
 if (ANDROID)
   SET(VMCS_INSTALL_PREFIX "/vendor/brcm/islands" CACHE PATH "Prefix prepended to install directories" FORCE)
-else()
+elseif(NOT DEFINED VMCS_INSTALL_PREFIX)
   SET(VMCS_INSTALL_PREFIX "/opt/vc" CACHE PATH "Prefix prepended to install directories" FORCE)
 endif()
 


### PR DESCRIPTION
Allow to override VMCS_INSTALL_PREFIX to be able to install to a user defined place