### PR TITLE
raspiyuv: Flush stdout to ensure image is fully sent

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -1376,6 +1376,10 @@ int main(int argc, const char **argv)
                {
                   rename_file(&state, output_file, final_filename, use_filename, frame);
                }
+               else
+               {
+                  fflush(output_file);
+               }
             }
 
             if (use_filename)


### PR DESCRIPTION
This PR adds a manual flush after writing the image data to stdout.

Without the flush, using signals to stream image data over stdout would result in the missing data, if the image didn't completely fill the buffer.

For validation, a 640x480 YUV image will consist of the following number of bytes:
 * Y: 640 x 480 = 307200 bytes
 * U: 640 x 480 ÷ 4 = 76800 bytes
 * V: 640 x 480 ÷ 4 = 76800 bytes
 * Sum: **460800 bytes**.

## Example

Prior to the patch, this is what happens when you pipe the image data over standard out and wait for SIGUSR1 to take a shot.

```sh
raspiyuv -o - -w 640 -h 480  --nopreview --signal | wc
  18134    2498  458752
```

Notice how `458752` is exactly `7 x 65536`. *It's missing the remaining `2048` bytes*, which doesn't automatically trigger a flush.

And after the patch:

```sh
$ raspiyuv -o - -w 640 -h 480  --nopreview --signal | wc
  17043    2602  460800
```

For both examples, triggering the shot in a separate shell:
```sh
kill -SIGUSR1 $(ps -C raspiyuv --no-headers -o "pid")
sleep 2
kill $(ps -C raspiyuv --no-headers -o "pid")
```

Please let me know if there is anything else you need from me. 

Thanks!
-Kevin