### PR TITLE
Adjust include paths for Linux/BSD.

### DIFF
--- a/interface/vcos/pthreads/vcos_platform.h
+++ b/interface/vcos/pthreads/vcos_platform.h
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 VideoCore OS Abstraction Layer - pthreads types
 =============================================================================*/
 
-/* Do not include this file directly - instead include it via vcos.h */
+/* DO NOT include this file directly - instead include it via vcos.h */
 
 /** @file
   *

--- a/interface/vcos/vcos.h
+++ b/interface/vcos/vcos.h
@@ -113,7 +113,12 @@ VideoCore OS Abstraction Layer - public header file
 
 #include "interface/vcos/vcos_assert.h"
 #include "vcos_types.h"
+
+#if defined(__unix__) && !defined(__ANDROID__)
+#include "interface/vcos/pthreads/vcos_platform.h"
+#else
 #include "vcos_platform.h"
+#endif
 
 #ifndef VCOS_INIT_H
 #include "interface/vcos/vcos_init.h"

--- a/interface/vcos/vcos_atomic_flags.h
+++ b/interface/vcos/vcos_atomic_flags.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
  * \file vcos_atomic_flags.h

--- a/interface/vcos/vcos_blockpool.h
+++ b/interface/vcos/vcos_blockpool.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /** \file
   *

--- a/interface/vcos/vcos_cfg.h
+++ b/interface/vcos/vcos_cfg.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 typedef struct opaque_vcos_cfg_buf_t    *VCOS_CFG_BUF_T;
 typedef struct opaque_vcos_cfg_entry_t  *VCOS_CFG_ENTRY_T;

--- a/interface/vcos/vcos_dlfcn.h
+++ b/interface/vcos/vcos_dlfcn.h
@@ -33,7 +33,7 @@ VCOS - abstraction over dynamic library opening
 #define VCOS_DLFCN_H
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/interface/vcos/vcos_event.h
+++ b/interface/vcos/vcos_event.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /** 
   * \file

--- a/interface/vcos/vcos_event_flags.h
+++ b/interface/vcos/vcos_event_flags.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 #define VCOS_EVENT_FLAGS_SUSPEND    VCOS_SUSPEND
 #define VCOS_EVENT_FLAGS_NO_SUSPEND VCOS_NO_SUSPEND

--- a/interface/vcos/vcos_init.h
+++ b/interface/vcos/vcos_init.h
@@ -31,7 +31,7 @@ VideoCore OS Abstraction Layer - initialization routines
 
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/interface/vcos/vcos_isr.h
+++ b/interface/vcos/vcos_isr.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
   * \file vcos_isr.h

--- a/interface/vcos/vcos_legacy_isr.h
+++ b/interface/vcos/vcos_legacy_isr.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /** \file vcos_legacy_isr.h
   *

--- a/interface/vcos/vcos_logging.h
+++ b/interface/vcos/vcos_logging.h
@@ -39,7 +39,7 @@ extern "C" {
 #include <stdarg.h>
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 #include "vcos_logging_control.h"
 
 /**

--- a/interface/vcos/vcos_lowlevel_thread.h
+++ b/interface/vcos/vcos_lowlevel_thread.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #include "interface/vcos/vcos_types.h"
 #ifndef VCOS_PLATFORM_H
-#include "vcos_platform.h"
+#include "vcos.h"
 #endif
 
 /**

--- a/interface/vcos/vcos_mem.h
+++ b/interface/vcos/vcos_mem.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /** \file
   *

--- a/interface/vcos/vcos_mempool.h
+++ b/interface/vcos/vcos_mempool.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /** \file
   *

--- a/interface/vcos/vcos_msgqueue.h
+++ b/interface/vcos/vcos_msgqueue.h
@@ -44,7 +44,7 @@ extern "C" {
 #endif
 
 #include "vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 #include "vcos_blockpool.h"
 
 /**

--- a/interface/vcos/vcos_mutex.h
+++ b/interface/vcos/vcos_mutex.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
  * \file vcos_mutex.h

--- a/interface/vcos/vcos_named_semaphore.h
+++ b/interface/vcos/vcos_named_semaphore.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
  * \file

--- a/interface/vcos/vcos_once.h
+++ b/interface/vcos/vcos_once.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
  * \file vcos_once.h

--- a/interface/vcos/vcos_queue.h
+++ b/interface/vcos/vcos_queue.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /** \file vcos_queue.h
   *

--- a/interface/vcos/vcos_quickslow_mutex.h
+++ b/interface/vcos/vcos_quickslow_mutex.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
  * \file vcos_quickslow_mutex.h

--- a/interface/vcos/vcos_reentrant_mutex.h
+++ b/interface/vcos/vcos_reentrant_mutex.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
  * \file

--- a/interface/vcos/vcos_semaphore.h
+++ b/interface/vcos/vcos_semaphore.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #include "interface/vcos/vcos_types.h"
 #ifndef VCOS_PLATFORM_H
-#include "vcos_platform.h"
+#include "vcos.h"
 #endif
 
 /**

--- a/interface/vcos/vcos_string.h
+++ b/interface/vcos/vcos_string.h
@@ -44,7 +44,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 #ifdef __KERNEL__
 #include <linux/string.h>

--- a/interface/vcos/vcos_thread.h
+++ b/interface/vcos/vcos_thread.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 /**
  * \file vcos_thread.h

--- a/interface/vcos/vcos_timer.h
+++ b/interface/vcos/vcos_timer.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #include "interface/vcos/vcos_types.h"
 #ifndef VCOS_PLATFORM_H
-#include "vcos_platform.h"
+#include "vcos.h"
 #endif
 
 /** \file vcos_timer.h

--- a/interface/vcos/vcos_tls.h
+++ b/interface/vcos/vcos_tls.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 #include "interface/vcos/vcos_types.h"
-#include "vcos_platform.h"
+#include "vcos.h"
 
 
 /** Create a new thread local storage data key visible to all threads in

--- a/interface/vcos/vcos_types.h
+++ b/interface/vcos/vcos_types.h
@@ -35,11 +35,15 @@ VideoCore OS Abstraction Layer - basic types
 #define VCOS_VERSION   1
 
 #include <stddef.h>
+#if defined(__unix__) && !defined(__ANDROID__)
+#include "interface/vcos/pthreads/vcos_platform_types.h"
+#else
 #include "vcos_platform_types.h"
+#endif
 #include "interface/vcos/vcos_attr.h"
 
 #if !defined(VCOSPRE_) || !defined(VCOSPOST_)
-#error VCOSPRE_ and VCOSPOST_ not defined!
+#error VCOSPRE_ or VCOSPOST_ not defined!
 #endif
 
 /* Redefine these here; this means that existing header files can carry on

--- a/interface/vmcs_host/vc_vchi_cecservice.c
+++ b/interface/vmcs_host/vc_vchi_cecservice.c
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <string.h>
 #include <stdio.h>
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "vchost.h"
 
 #include "interface/vcos/vcos.h"

--- a/interface/vmcs_host/vc_vchi_dispmanx.c
+++ b/interface/vmcs_host/vc_vchi_dispmanx.c
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <stdlib.h>
 
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "vchost.h"
 
 #include "interface/vcos/vcos.h"

--- a/interface/vmcs_host/vc_vchi_filesys.h
+++ b/interface/vmcs_host/vc_vchi_filesys.h
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef VC_VCHI_VCFILESYS_H_
 #define VC_VCHI_VCFILESYS_H_
 
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "vcfilesys_defs.h"
 #include "vc_fileservice_defs.h"
 #include "interface/vchi/vchi.h"

--- a/interface/vmcs_host/vc_vchi_gencmd.h
+++ b/interface/vmcs_host/vc_vchi_gencmd.h
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef VC_VCHI_GENCMD_H
 #define VC_VCHI_GENCMD_H
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "interface/vchi/vchi.h"
 #include "interface/vcos/vcos.h" //for VCHPRE_ abd VCHPOST_ macro's for func declaration
 

--- a/interface/vmcs_host/vc_vchi_tvservice.c
+++ b/interface/vmcs_host/vc_vchi_tvservice.c
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "interface/vcos/vcos.h"
 
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "vchost.h"
 
 #include "interface/vchi/vchi.h"

--- a/interface/vmcs_host/vcfilesys.h
+++ b/interface/vmcs_host/vcfilesys.h
@@ -25,7 +25,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "vcfilesys_defs.h"
 #include "vc_fileservice_defs.h"
 

--- a/interface/vmcs_host/vcgencmd.h
+++ b/interface/vmcs_host/vcgencmd.h
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GENCMD_H
 #define GENCMD_H
 
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "interface/vchi/vchi.h"
 
 VCHPRE_ void VCHPOST_ vc_vchi_gencmd_init(VCHI_INSTANCE_T initialise_instance, VCHI_CONNECTION_T **connections, uint32_t num_connections );

--- a/interface/vmcs_host/vchost.h
+++ b/interface/vmcs_host/vchost.h
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef VCHOST_H
 #define VCHOST_H
 
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include "vcfilesys_defs.h"
 #include "interface/vcos/vcos.h" //for VCHPRE_ abd VCHPOST_ macro's for func declaration
 #include "interface/vmcs_host/vc_fileservice_defs.h" // for VC_O_XXX file definitions

--- a/interface/vmcs_host/vchost_platform_config.h
+++ b/interface/vmcs_host/vchost_platform_config.h
@@ -1,0 +1,5 @@
+#if defined(__unix__) && !defined(__ANDROID__)
+#include "linux/vchost_config.h"
+#else
+#include "vchost_config.h"
+#endif

--- a/interface/vmcs_host/vchostreq.h
+++ b/interface/vmcs_host/vchostreq.h
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define VCHOSTREQ_H
 
 #include "vc_hostreq_defs.h"
-#include "vchost_config.h"
+#include "vchost_platform_config.h"
 #include <time.h>
 
 #include "interface/vchi/vchi.h"


### PR DESCRIPTION
Include pthreads path directly on __UNIX__ . Tested that Userland still builds on Raspbian, but may  have impact on other platforms e.g. Android. 