### PR TITLE
Use of glob.h breaks Android builds.

### DIFF
--- a/host_applications/linux/apps/dtoverlay/dtoverlay_main.c
+++ b/host_applications/linux/apps/dtoverlay/dtoverlay_main.c
@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <unistd.h>
 #include <stdarg.h>
-#include <glob.h>
 #include <sys/stat.h>
 #include <dirent.h>
 #include <errno.h>
@@ -503,7 +502,7 @@ static int dtoverlay_list_all(STATE_T *state)
 	char *str;
 	int idx;
 
-	sprintf(suffix, " [%d]", i + 1);
+	snprintf(suffix, 16," [%d]", i + 1);
 	left = strchr(state->namelist[i]->d_name, '_');
 	if (!left)
 	    return error("Internal error");


### PR DESCRIPTION
glob is not used here, so glob.h need not be included.

Also, sprintf is obsolete and throws compiler warnings no matter how obviously safe this one is. This is not the only example in the code base, but there is no need to make things worse.