### PR TITLE
openvg: vguPolygon incorrect coordinate pointer increment

### DIFF
--- a/interface/khronos/vg/vg_client.c
+++ b/interface/khronos/vg/vg_client.c
@@ -5122,7 +5122,7 @@ VGU_API_CALL VGUErrorCode VGU_API_ENTRY vguPolygon(
             rpc_send_ctrl_end(thread);
 
             ps_count -= chunk_ps_count;
-            ps += chunk_ps_count;
+            ps += 2 * chunk_ps_count;
             first = false;
          }
       }


### PR DESCRIPTION
The pointer to the start of the next coordinate to send was incorrectly incremented (by 1*count rather than the 2*count sent).