### PR TITLE
Do not return random data

### DIFF
--- a/interface/vchiq_arm/vchiq_lib.c
+++ b/interface/vchiq_arm/vchiq_lib.c
@@ -161,6 +161,7 @@ VCHIQ_STATUS_T
 vchiq_initialise(VCHIQ_INSTANCE_T *pinstance)
 {
    vchiq_initialise_fd(pinstance, -1);
+   return NULL;
 }
 
 VCHIQ_STATUS_T


### PR DESCRIPTION
This would solve issues  with openSUSE packagign - automatic check complaining:
```
I: Program returns random data in a function
E: raspberrypi-userland no-return-in-nonvoid-function /home/abuild/rpmbuild/BUILD/raspberrypi-userland-2016.08.17/interface/vchiq_arm/vchiq_lib.c:164

```