### PR TITLE
Fix definition of UNUSED(x)

### DIFF
--- a/interface/khronos/common/khrn_int_common.h
+++ b/interface/khronos/common/khrn_int_common.h
@@ -162,14 +162,10 @@ typedef unsigned long long uint64_t;
 #ifdef _MSC_VER
    #define UNUSED(X) X
 #else
-   #define UNUSED(X)
+   #define UNUSED(X) (void)(X)
 #endif
 
-#ifdef NDEBUG
-   #define UNUSED_NDEBUG(X) UNUSED(X)
-#else
-   #define UNUSED_NDEBUG(X)
-#endif
+#define UNUSED_NDEBUG(X) UNUSED(X)
 
 #define KHRN_NO_SEMAPHORE 0xffffffff
 


### PR DESCRIPTION
Make UNUSED(x) explicitly cast (x) to void. This fixes a number
of compiler warnings.

See also #188.