### PR TITLE
Remove vcos_get_free_mem()

### DIFF
--- a/interface/vcos/pthreads/vcos_platform.h
+++ b/interface/vcos/pthreads/vcos_platform.h
@@ -674,11 +674,11 @@ void vcos_atomic_flags_delete(VCOS_ATOMIC_FLAGS_T *atomic_flags)
 
 #if defined(linux) || defined(_HAVE_SBRK)
 
-/* not exactly the free memory, but a measure of it */
+/* Returns invalid result, do not use */
 
 VCOS_INLINE_IMPL
-unsigned long vcos_get_free_mem(void) {
-   return (unsigned long)sbrk(0);
+unsigned long VCOS_DEPRECATED("returns invalid result") vcos_get_free_mem(void) {
+   return 0;
 }
 
 #endif

--- a/interface/vcos/vcos_types.h
+++ b/interface/vcos/vcos_types.h
@@ -280,4 +280,10 @@ typedef vcos_fourcc_t FOURCC_T;
 # define VCOS_WEAK_ALIAS_STR(ret_type, alias, params, target)  VCOS_CASSERT(0)
 #endif
 
+#if defined(__GNUC__)
+#define VCOS_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#define VCOS_DEPRECATED(msg)
+#endif
+
 #endif


### PR DESCRIPTION
This function isn't used anywhere, and causes compiler warnings
due to its use of sbrk() without the relevant #defines.

The "pthreads" version of this doesn't do anything sensible: on
a linux system it should look at something like /proc/vmstat,
but that's not what it does. So additionally remove it to avoid
confusion.

See issue #316.