### PR TITLE
buildme: avoid shell expansion of tr expression

### DIFF
--- a/buildme
+++ b/buildme
@@ -6,7 +6,7 @@ BUILDTYPE=Debug
 shift
 fi
 
-BUILDSUBDIR=`echo $BUILDTYPE | tr [A-Z] [a-z]`;
+BUILDSUBDIR=`echo $BUILDTYPE | tr '[A-Z]' '[a-z]'`;
 
 if [ "armv6l" = `arch` ] || [ "armv7l" = `arch` ]; then
 	# Native compile on the Raspberry Pi


### PR DESCRIPTION
I found out by accident that buildme doesn't do quite enough escaping of the "tr" command's arguments. It was quite puzzling....