### PR TITLE
Warnings/vcos verify

### DIFF
--- a/interface/khronos/common/linux/khrn_client_platform_linux.c
+++ b/interface/khronos/common/linux/khrn_client_platform_linux.c
@@ -273,7 +273,9 @@ static KHRN_IMAGE_FORMAT_T convert_format(uint32_t format)
       case EGL_PIXEL_FORMAT_XRGB_8888_BRCM:     return XBGR_8888;
       case EGL_PIXEL_FORMAT_RGB_565_BRCM:       return RGB_565;
       case EGL_PIXEL_FORMAT_A_8_BRCM:           return A_8;
-      default:                                  vcos_verify(0); return (KHRN_IMAGE_FORMAT_T)0;
+      default:
+         vcos_assert(0);
+         return (KHRN_IMAGE_FORMAT_T)0;
    }
 }
 

--- a/interface/khronos/egl/egl_client.c
+++ b/interface/khronos/egl/egl_client.c
@@ -1740,7 +1740,7 @@ static void send_pixmap(EGL_SURFACE_T *surface)
       KHRN_IMAGE_WRAP_T image;
 
       if (!platform_get_pixmap_info(surface->pixmap, &image)) {
-         vcos_verify(0); /* the pixmap has become invalid... */
+         (void)vcos_verify(0); /* the pixmap has become invalid... */
          return;
       }
 
@@ -1819,7 +1819,7 @@ static void retrieve_pixmap(EGL_SURFACE_T *surface, bool wait)
       KHRN_IMAGE_WRAP_T image;
 
       if (!platform_get_pixmap_info(surface->pixmap, &image)) {
-         vcos_verify(0); /* the pixmap has become invalid... */
+         (void)vcos_verify(0); /* the pixmap has become invalid... */
          return;
       }
 


### PR DESCRIPTION
RFC: remove a few warnings around vcos_verify().

Vcos_verify() was originally intended to be used like this:

    if (!vcos_verify(condition_expected_to_be_true))
        handle_unexpected_error_somehow();

The idea is that in normal use vcos_verify just evaluates its argument, but if you are trying to debug a problem it can be flipped via a build-time switch to generate a breakpoint and drop to a debugger.

The compiler is now warning that the rvalue is ignored in a few places where it is used outside a conditional stmnt.

It is not correct to blithely do s/vcos_verify/vcos_assert/g as behaviour will change.

One fix is to cast all the result to (void). I have actually chosen to switch one instance to a vcos_assert() because the code there looks like it should be an assert, and leave the others alone (but cast to void to squelch the warning).

 