### PR TITLE
3 minor raspicam updates

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1277,7 +1277,7 @@ static MMAL_STATUS_T create_encoder_component(RASPISTILL_STATE *state)
    // Set the JPEG restart interval
    status = mmal_port_parameter_set_uint32(encoder_output, MMAL_PARAMETER_JPEG_RESTART_INTERVAL, state->restart_interval);
 
-   if (status != MMAL_SUCCESS)
+   if (state->restart_interval && status != MMAL_SUCCESS)
    {
       vcos_log_error("Unable to set JPEG restart interval");
       goto error;

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1214,6 +1214,17 @@ static void encoder_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
                   pData->imv_file_handle = new_handle;
                }
             }
+
+            if (pData->pstate->pts_filename && pData->pstate->pts_filename[0] != '-')
+            {
+               new_handle = open_filename(pData->pstate, pData->pstate->pts_filename);
+
+               if (new_handle)
+               {
+                  fclose(pData->pts_file_handle);
+                  pData->pts_file_handle = new_handle;
+               }
+            }
          }
          if (buffer->length)
          {

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1193,20 +1193,26 @@ static void encoder_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
             if (pData->pstate->segmentWrap && pData->pstate->segmentNumber > pData->pstate->segmentWrap)
                pData->pstate->segmentNumber = 1;
 
-            new_handle = open_filename(pData->pstate, pData->pstate->filename);
-
-            if (new_handle)
+            if (pData->pstate->filename && pData->pstate->filename[0] != '-')
             {
-               fclose(pData->file_handle);
-               pData->file_handle = new_handle;
+               new_handle = open_filename(pData->pstate, pData->pstate->filename);
+
+               if (new_handle)
+               {
+                  fclose(pData->file_handle);
+                  pData->file_handle = new_handle;
+               }
             }
 
-            new_handle = open_filename(pData->pstate, pData->pstate->imv_filename);
-
-            if (new_handle)
+            if (pData->pstate->imv_filename && pData->pstate->imv_filename[0] != '-')
             {
-               fclose(pData->imv_file_handle);
-               pData->imv_file_handle = new_handle;
+               new_handle = open_filename(pData->pstate, pData->pstate->imv_filename);
+
+               if (new_handle)
+               {
+                  fclose(pData->imv_file_handle);
+                  pData->imv_file_handle = new_handle;
+               }
             }
          }
          if (buffer->length)


### PR DESCRIPTION
Setting the restart interval isn't supported on older firmwares, so aborting is a touch excessive as long as it isn't set.

Segmentation option could try opening a null filename.

Option to segment timestamps file as well as encoded data and motion vectors.