### PR TITLE
Zooming in, out and reset zoom while capturing video. 

### DIFF
--- a/host_applications/linux/apps/raspicam/README.md
+++ b/host_applications/linux/apps/raspicam/README.md
@@ -299,7 +299,9 @@ This runs the preview windows using the full resolution capture mode. Maximum fr
 
 	--keypress		-k	Keypress mode
 
-The camera is run for the requested time (-t), and a captures can be initiated throughout that by pressing the Enter key.  Press X then Enter will exit the application before the timeout is reached. If the timeout is set to 0, the camera will run indefinitely until X then Enter is typed. Using the verbose option (-v) will display a prompt asking for user input, otherwise no prompt is displayed. 
+The camera is run for the requested time (-t), and a captures can be initiated throughout that by pressing the Enter key.  Press X then Enter will exit the application before the timeout is reached. If the timeout is set to 0, the camera will run indefinitely until X then Enter is typed.
+Additional supported keys: 'i', 'o' and 'r'. Press 'i' then Enter will zoom in by 10%. Press 'o' then Enter will zoom out by 10%.  Press 'r' then Enter will reset zoom.
+Using the verbose option (-v) will display a prompt asking for user input, otherwise no prompt is displayed.
 
 	--signal			-s	Signal mode
 

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -1360,10 +1360,10 @@ int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect)
 /**
  * Zoom in and Zoom out by changing ROI
  * @param camera Pointer to camera component
- * @param zoom_level zoom level enum
+ * @param zoom_command zoom command enum
  * @return 0 if successful, non-zero otherwise
  */
-int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zoom_level, PARAM_FLOAT_RECT_T *roi) {
+int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zoom_command, PARAM_FLOAT_RECT_T *roi) {
     MMAL_PARAMETER_INPUT_CROP_T crop;
     crop.hdr.id = MMAL_PARAMETER_INPUT_CROP;
     crop.hdr.size = sizeof(crop);
@@ -1374,7 +1374,7 @@ int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zo
         return 0;
     }
 
-    if (zoom_level == ZOOM_IN)
+    if (zoom_command == ZOOM_IN)
     {
         if (crop.rect.width <= (zoom_full_16P16 + zoom_increment_16P16))
         {
@@ -1387,7 +1387,7 @@ int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zo
             crop.rect.height -= zoom_increment_16P16;
         }
     }
-    else if (zoom_level == ZOOM_OUT)
+    else if (zoom_command == ZOOM_OUT)
     {
         unsigned int increased_size = crop.rect.width + zoom_increment_16P16;
         if (increased_size < crop.rect.width) //overflow
@@ -1402,7 +1402,7 @@ int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zo
         }
     }
 
-    if (zoom_level == ZOOM_RESET)
+    if (zoom_command == ZOOM_RESET)
     {
         crop.rect.x = 0;
         crop.rect.y = 0;

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -834,7 +834,6 @@ void raspicamcontrol_dump_parameters(const RASPICAM_CAMERA_PARAMETERS *params)
    fprintf(stderr, "Metering Mode '%s', Colour Effect Enabled %s with U = %d, V = %d\n", metering_mode, params->colourEffects.enable ? "Yes":"No", params->colourEffects.u, params->colourEffects.v);
    fprintf(stderr, "Rotation %d, hflip %s, vflip %s\n", params->rotation, params->hflip ? "Yes":"No",params->vflip ? "Yes":"No");
    fprintf(stderr, "ROI x %lf, y %f, w %f h %f\n", params->roi.x, params->roi.y, params->roi.w, params->roi.h);
-   fprintf(stderr, "Nostopstate %s\n", params->n, params->roi.y, params->roi.w, params->roi.h);
 }
 
 /**

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -195,7 +195,7 @@ static int cmdline_commands_size = sizeof(cmdline_commands) / sizeof(cmdline_com
 
 #define parameter_reset -99999
 
-static const unsigned int min_zoom_size_16P16 = 65536 * 0.2;
+static const unsigned int min_zoom_size_16P16 = 65536 * 0.1;
 static const unsigned int max_zoom_size_16P16 = 65536 * 0.9;
 static const unsigned int zoom_increment_16P16 = 65536 * 0.1;
 
@@ -1390,11 +1390,19 @@ int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZoomLevel zoom_le
     }
     else if (zoom_level == ZOOM_OUT)
     {
-        crop.rect.width += zoom_increment_16P16;
-        crop.rect.height += zoom_increment_16P16;
+        if (crop.rect.width >= max_zoom_size_16P16)
+        {
+            crop.rect.width = 65536;
+            crop.rect.height = 65536;
+        }
+        else
+        {
+            crop.rect.width += zoom_increment_16P16;
+            crop.rect.height += zoom_increment_16P16;
+        }
     }
 
-    if (zoom_level == ZOOM_RESET || crop.rect.width >= max_zoom_size_16P16)
+    if (zoom_level == ZOOM_RESET)
     {
         crop.rect.x = 0;
         crop.rect.y = 0;

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.h
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.h
@@ -191,6 +191,7 @@ int raspicamcontrol_set_colourFX(MMAL_COMPONENT_T *camera, const MMAL_PARAM_COLO
 int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation);
 int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip);
 int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect);
+int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, int zoom_level);
 int raspicamcontrol_set_shutter_speed(MMAL_COMPONENT_T *camera, int speed_ms);
 int raspicamcontrol_set_DRC(MMAL_COMPONENT_T *camera, MMAL_PARAMETER_DRC_STRENGTH_T strength);
 int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass);

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.h
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.h
@@ -161,7 +161,7 @@ typedef struct raspicam_camera_parameters_s
 
 typedef enum {
     ZOOM_IN, ZOOM_OUT, ZOOM_RESET
-} ZoomLevel;
+} ZOOM_COMMAND_T;
 
 
 void raspicamcontrol_check_configuration(int min_gpu_mem);
@@ -195,7 +195,7 @@ int raspicamcontrol_set_colourFX(MMAL_COMPONENT_T *camera, const MMAL_PARAM_COLO
 int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation);
 int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip);
 int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect);
-int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZoomLevel zoom_level);
+int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zoom_command, PARAM_FLOAT_RECT_T *roi);
 int raspicamcontrol_set_shutter_speed(MMAL_COMPONENT_T *camera, int speed_ms);
 int raspicamcontrol_set_DRC(MMAL_COMPONENT_T *camera, MMAL_PARAMETER_DRC_STRENGTH_T strength);
 int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass);

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.h
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.h
@@ -159,6 +159,10 @@ typedef struct raspicam_camera_parameters_s
    MMAL_PARAMETER_STEREOSCOPIC_MODE_T stereo_mode;
 } RASPICAM_CAMERA_PARAMETERS;
 
+typedef enum {
+    ZOOM_IN, ZOOM_OUT, ZOOM_RESET
+} ZoomLevel;
+
 
 void raspicamcontrol_check_configuration(int min_gpu_mem);
 
@@ -191,7 +195,7 @@ int raspicamcontrol_set_colourFX(MMAL_COMPONENT_T *camera, const MMAL_PARAM_COLO
 int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation);
 int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip);
 int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect);
-int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, int zoom_level);
+int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZoomLevel zoom_level);
 int raspicamcontrol_set_shutter_speed(MMAL_COMPONENT_T *camera, int speed_ms);
 int raspicamcontrol_set_DRC(MMAL_COMPONENT_T *camera, MMAL_PARAMETER_DRC_STRENGTH_T strength);
 int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass);

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2305,21 +2305,21 @@ static int wait_for_next_change(RASPIVID_STATE *state)
          if (state->verbose)
             fprintf(stderr, "Starting zoom in\n");
 
-         raspicamcontrol_zoom_in_zoom_out(state->camera_component, 1);
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_IN);
       }
       else if (ch == 'o')
       {
          if (state->verbose)
             fprintf(stderr, "Starting zoom out\n");
 
-         raspicamcontrol_zoom_in_zoom_out(state->camera_component, 2);
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_OUT);
       }
       else if (ch == 'r')
       {
          if (state->verbose)
             fprintf(stderr, "starting reset zoom\n");
 
-         raspicamcontrol_zoom_in_zoom_out(state->camera_component, 3);
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_RESET);
       }
 
       return keep_running;

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -211,7 +211,6 @@ struct RASPIVID_STATE_S
 
    int bCapturing;                     /// State of capture/pause
    int bCircularBuffer;                /// Whether we are writing to a circular buffer
-   int bChangeStateWithoutStopCapture; /// Whether we are changing camera state without stop capturing
 
    int inlineMotionVectors;             /// Encoder outputs inline Motion Vectors
    char *imv_filename;                  /// filename of inline Motion Vectors output
@@ -317,7 +316,6 @@ static void display_valid_parameters(char *app_name);
 #define CommandLevel        31
 #define CommandRaw          32
 #define CommandRawFormat    33
-#define CommandStateNoStop  34
 
 static COMMAND_LIST cmdline_commands[] =
 {
@@ -335,8 +333,7 @@ static COMMAND_LIST cmdline_commands[] =
    { CommandProfile,       "-profile",    "pf", "Specify H264 profile to use for encoding", 1},
    { CommandTimed,         "-timed",      "td", "Cycle between capture and pause. -cycle on,off where on is record time and off is pause time in ms", 0},
    { CommandSignal,        "-signal",     "s",  "Cycle between capture and pause on Signal", 0},
-   { CommandKeypress,      "-keypress",   "k",  "Cycle between capture and pause on ENTER unless nostopstate option specified", 0},
-   { CommandStateNoStop,   "-nostopstate","ns", "Any state modifications without camera capture pausing", 0},
+   { CommandKeypress,      "-keypress",   "k",  "Cycle between capture and pause on ENTER", 0},
    { CommandInitialState,  "-initial",    "i",  "Initial state. Use 'record' or 'pause'. Default 'record'", 1},
    { CommandQP,            "-qp",         "qp", "Quantisation parameter. Use approximately 10-40. Default 0 (off)", 1},
    { CommandInlineHeaders, "-inline",     "ih", "Insert inline headers (SPS, PPS) to stream", 0},
@@ -413,7 +410,6 @@ static void default_status(RASPIVID_STATE *state)
    state->offTime = 5000;
 
    state->bCapturing = 0;
-   state->bChangeStateWithoutStopCapture = 0;
    state->bInlineHeaders = 0;
 
    state->segmentSize = 0;  // 0 = not segmenting the file.
@@ -702,12 +698,6 @@ static int parse_cmdline(int argc, const char **argv, RASPIVID_STATE *state)
 
          i++;
          break;
-      }
-
-      case CommandStateNoStop:
-      {
-          state->bChangeStateWithoutStopCapture = 1;
-          break;
       }
 
       case CommandSegmentFile: // Segment file in to chunks of specified time
@@ -2305,26 +2295,26 @@ static int wait_for_next_change(RASPIVID_STATE *state)
       char ch;
 
       if (state->verbose)
-         fprintf(stderr, "Press Enter to %s, X then ENTER to exit\n", state->bCapturing ? "pause" : "capture");
+         fprintf(stderr, "Press Enter to %s, X then ENTER to exit, [i,o,r] change zoom\n", state->bCapturing ? "pause" : "capture");
 
       ch = getchar();
       if (ch == 'x' || ch == 'X')
          return 0;
-      else if (ch == 'i')
+      else if (ch == 'i' || ch == 'I')
       {
          if (state->verbose)
             fprintf(stderr, "Starting zoom in\n");
 
          raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_IN);
       }
-      else if (ch == 'o')
+      else if (ch == 'o' || ch == 'O')
       {
          if (state->verbose)
             fprintf(stderr, "Starting zoom out\n");
 
          raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_OUT);
       }
-      else if (ch == 'r')
+      else if (ch == 'r' || ch == 'R')
       {
          if (state->verbose)
             fprintf(stderr, "starting reset zoom\n");
@@ -2779,7 +2769,8 @@ int main(int argc, const char **argv)
                int initialCapturing=state.bCapturing;
                while (running)
                {
-                   // Change state
+                  // Change state
+
                   state.bCapturing = !state.bCapturing;
 
                   if (mmal_port_parameter_set_boolean(camera_video_port, MMAL_PARAMETER_CAPTURE, state.bCapturing) != MMAL_SUCCESS)
@@ -2796,7 +2787,7 @@ int main(int argc, const char **argv)
                   if (state.verbose)
                   {
                      if (state.bCapturing)
-                        fprintf(stderr, "Capturing video\n");
+                        fprintf(stderr, "Starting video capture\n");
                      else
                         fprintf(stderr, "Pausing video capture\n");
                   }

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2295,7 +2295,7 @@ static int wait_for_next_change(RASPIVID_STATE *state)
       char ch;
 
       if (state->verbose)
-         fprintf(stderr, "Press Enter to %s, X then ENTER to exit, [i,o,r] change zoom\n", state->bCapturing ? "pause" : "capture");
+         fprintf(stderr, "Press Enter to %s, X then ENTER to exit, [i,o,r] then ENTER to change zoom\n", state->bCapturing ? "pause" : "capture");
 
       ch = getchar();
       if (ch == 'x' || ch == 'X')
@@ -2305,21 +2305,30 @@ static int wait_for_next_change(RASPIVID_STATE *state)
          if (state->verbose)
             fprintf(stderr, "Starting zoom in\n");
 
-         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_IN);
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_IN, &(state->camera_parameters).roi);
+
+         if (state->verbose)
+            dump_status(state);
       }
       else if (ch == 'o' || ch == 'O')
       {
          if (state->verbose)
             fprintf(stderr, "Starting zoom out\n");
 
-         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_OUT);
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_OUT, &(state->camera_parameters).roi);
+
+         if (state->verbose)
+            dump_status(state);
       }
       else if (ch == 'r' || ch == 'R')
       {
          if (state->verbose)
             fprintf(stderr, "starting reset zoom\n");
 
-         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_RESET);
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, ZOOM_RESET, &(state->camera_parameters).roi);
+
+         if (state->verbose)
+            dump_status(state);
       }
 
       return keep_running;

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2300,53 +2300,31 @@ static int wait_for_next_change(RASPIVID_STATE *state)
       ch = getchar();
       if (ch == 'x' || ch == 'X')
          return 0;
-      else if (ch == 'a' || ch == 'b') {
-          if (state->verbose)
-              fprintf(stderr, "starting zoom\n");
+      else if (ch == 'i')
+      {
+         if (state->verbose)
+            fprintf(stderr, "Starting zoom in\n");
 
-          MMAL_PARAMETER_INPUT_CROP_T crop;
-          crop.hdr.id = MMAL_PARAMETER_INPUT_CROP;
-          crop.hdr.size = sizeof(crop);
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, 1);
+      }
+      else if (ch == 'o')
+      {
+         if (state->verbose)
+            fprintf(stderr, "Starting zoom out\n");
 
-          if (mmal_port_parameter_get(state->camera_component->control, &crop.hdr) == MMAL_SUCCESS) {
-              if (state->verbose)
-                  fprintf(stderr, "Got crop successfully\n");
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, 2);
+      }
+      else if (ch == 'r')
+      {
+         if (state->verbose)
+            fprintf(stderr, "starting reset zoom\n");
 
-              crop.rect.x = (65536 * 0.4);
-              crop.rect.y = (65536 * 0.5);
-
-              if (ch == 'a') {
-                  if (state->verbose)
-                      fprintf(stderr, "Increase zoom\n");
-
-                  if (crop.rect.width >= (65536 * 0.89)) {
-                      crop.rect.x = 0;
-                      crop.rect.y = 0;
-                      crop.rect.width = 65536;
-                      crop.rect.height = 65536;
-                  } else {
-                      crop.rect.width = crop.rect.width + (65536 * 0.1);
-                      crop.rect.height = crop.rect.height + (65536 * 0.1);
-                  }
-              } else {
-                  if (state->verbose)
-                      fprintf(stderr, "Decrease zoom\n");
-
-                  if (crop.rect.width <= (65536 * 0.31)) {
-                      crop.rect.width = (65536 * 0.3);
-                      crop.rect.height = (65536 * 0.3);
-                  } else {
-                      crop.rect.width = crop.rect.width - (65536 * 0.1);
-                      crop.rect.height = crop.rect.height - (65536 * 0.1);
-                  }
-              }
-
-              mmal_port_parameter_set(state->camera_component->control, &crop.hdr);
-          }
+         raspicamcontrol_zoom_in_zoom_out(state->camera_component, 3);
       }
 
-       return keep_running;
+      return keep_running;
    }
+
 
    case WAIT_METHOD_SIGNAL:
    {

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2300,8 +2300,52 @@ static int wait_for_next_change(RASPIVID_STATE *state)
       ch = getchar();
       if (ch == 'x' || ch == 'X')
          return 0;
-      else
-         return keep_running;
+      else if (ch == 'a' || ch == 'b') {
+          if (state->verbose)
+              fprintf(stderr, "starting zoom\n");
+
+          MMAL_PARAMETER_INPUT_CROP_T crop;
+          crop.hdr.id = MMAL_PARAMETER_INPUT_CROP;
+          crop.hdr.size = sizeof(crop);
+
+          if (mmal_port_parameter_get(state->camera_component->control, &crop.hdr) == MMAL_SUCCESS) {
+              if (state->verbose)
+                  fprintf(stderr, "Got crop successfully\n");
+
+              crop.rect.x = (65536 * 0.4);
+              crop.rect.y = (65536 * 0.5);
+
+              if (ch == 'a') {
+                  if (state->verbose)
+                      fprintf(stderr, "Increase zoom\n");
+
+                  if (crop.rect.width >= (65536 * 0.89)) {
+                      crop.rect.x = 0;
+                      crop.rect.y = 0;
+                      crop.rect.width = 65536;
+                      crop.rect.height = 65536;
+                  } else {
+                      crop.rect.width = crop.rect.width + (65536 * 0.1);
+                      crop.rect.height = crop.rect.height + (65536 * 0.1);
+                  }
+              } else {
+                  if (state->verbose)
+                      fprintf(stderr, "Decrease zoom\n");
+
+                  if (crop.rect.width <= (65536 * 0.31)) {
+                      crop.rect.width = (65536 * 0.3);
+                      crop.rect.height = (65536 * 0.3);
+                  } else {
+                      crop.rect.width = crop.rect.width - (65536 * 0.1);
+                      crop.rect.height = crop.rect.height - (65536 * 0.1);
+                  }
+              }
+
+              mmal_port_parameter_set(state->camera_component->control, &crop.hdr);
+          }
+      }
+
+       return keep_running;
    }
 
    case WAIT_METHOD_SIGNAL:


### PR DESCRIPTION
Zooming in, out and reset zoom while capturing video. We capture video using raspivid and send to our server. As we use h264 encoding as it is from Raspberry Pi, send to our server and show as it is in our frontend. No reencoding or video transformations, so using other tools to zoom in and zoom out are not suitable for us.