### PR TITLE
Add pkg-config file for mmal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ include_directories("${PROJECT_BINARY_DIR}")
 include(FindPkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
 	# Produce a pkg-config file
-	foreach(PCFILE bcm_host.pc  egl.pc  glesv2.pc  vg.pc brcmegl.pc  brcmglesv2.pc  brcmvg.pc )
+	foreach(PCFILE bcm_host.pc egl.pc glesv2.pc vg.pc brcmegl.pc brcmglesv2.pc  brcmvg.pc vcsm.pc mmal.pc )
 		configure_file("pkgconfig/${PCFILE}.in" "${PCFILE}" @ONLY)
 		install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/${PCFILE}"
 			DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")

--- a/pkgconfig/mmal.pc.in
+++ b/pkgconfig/mmal.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: MMAL
+Description: Multi-Media Abstraction Layer library for RPi
+Version: 1
+Requires: vcsm
+Libs: -L${libdir} -lmmal -lmmal_core -lmmal_util -lmmal_vc_client -lbcm_host
+Cflags: -I${includedir}

--- a/pkgconfig/vcsm.pc.in
+++ b/pkgconfig/vcsm.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: VCSM
+Description: VideoCore Shared Memory library for RPi
+Version: 1
+Libs: -L${libdir} -lvcsm
+Cflags: -I${includedir}


### PR DESCRIPTION
Presently a number of applications use the hardcoded library path for MMAL. I think we would be best to have a pkg-config file for it just like some of the other libraries provided.