### PR TITLE
RaspiStill: Fix regression in d35be767 - uninitialised variable

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -58,7 +58,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <errno.h>
 #include <sysexits.h>
 
-#define VERSION_STRING "v1.3.10"
+#define VERSION_STRING "v1.3.11"
 
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"
@@ -1772,7 +1772,7 @@ static void rename_file(RASPISTILL_STATE *state, FILE *output_file,
 int main(int argc, const char **argv)
 {
    // Our main data storage vessel..
-   RASPISTILL_STATE state;
+   RASPISTILL_STATE state = {0};
    int exit_code = EX_OK;
 
    MMAL_STATUS_T status = MMAL_SUCCESS;


### PR DESCRIPTION
d35be767 relied on state->width/height being zero before setting
up the defaults, but the state structure is just on the stack
in main() and not initialised.
Initialise the whole structure to 0.

https://www.raspberrypi.org/forums/viewtopic.php?f=43&t=175445