### PR TITLE
Add OpenGL library versioning

### DIFF
--- a/interface/khronos/CMakeLists.txt
+++ b/interface/khronos/CMakeLists.txt
@@ -93,3 +93,8 @@ target_link_libraries(brcmWFC brcmEGL)
 target_link_libraries(brcmOpenVG brcmEGL)
 
 install(TARGETS brcmEGL brcmGLESv2 brcmOpenVG brcmWFC DESTINATION lib)
+
+set(DESTDIR \$ENV{DESTDIR})
+include(GNUInstallDirs)
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libbrcmEGL.so ${DESTDIR}/${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libEGL.so.1)")
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink libbrcmGLESv2.so ${DESTDIR}/${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libGLESv2.so.2)")


### PR DESCRIPTION
Some applications like QtWebEngine require specific library versions.
Make them happy by providing that.

https://wiki.qt.io/RaspberryPi2EGLFS