### PR TITLE
host-apps/dtoverlay: don't install scripts in random location

### DIFF
--- a/host_applications/linux/apps/dtoverlay/CMakeLists.txt
+++ b/host_applications/linux/apps/dtoverlay/CMakeLists.txt
@@ -22,12 +22,4 @@ add_custom_command(TARGET dtoverlay POST_BUILD COMMAND ln;-sf;dtoverlay;dtparam)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dtparam DESTINATION bin)
 
 set(DTOVERLAY_SCRIPTS dtoverlay-pre dtoverlay-post)
-foreach(_script ${DTOVERLAY_SCRIPTS})
-   add_custom_command(
-     TARGET dtoverlay
-     COMMAND ${CMAKE_COMMAND}
-     -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${_script}
-     ${CMAKE_BINARY_DIR}/../../bin/${_script}
-   )
-endforeach()
 install(PROGRAMS ${DTOVERLAY_SCRIPTS} DESTINATION bin)


### PR DESCRIPTION
Currently, we add a custom command that installs the dtoverlay pre/post
scripts in ${CMAKE_BINARY_DIR}/../../bin

However:

  - this points outside of the package directory; it even points two
    directories higher;

  - when doing cross-compilation, this is definitely not the place where
    the /bin directory really is;

  - the scripts are already properly installed without this code.

Remove that code, it serves no purpose and breaks for cross-compilation.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>