### PR TITLE
bcm_host: Honor previously set value of CMAKE_SHARED_LINKER_FLAGS

### DIFF
--- a/host_applications/linux/libs/bcm_host/CMakeLists.txt
+++ b/host_applications/linux/libs/bcm_host/CMakeLists.txt
@@ -7,7 +7,7 @@ else ()
 endif ()
 
 # set this as we want all the source of vchostif to be available in libbcm_host
-set (CMAKE_SHARED_LINKER_FLAGS "-u vc_gpuserv_init")
+set (CMAKE_SHARED_LINKER_FLAGS "-u vc_gpuserv_init ${CMAKE_SHARED_LINKER_FLAGS}")
 
 include_directories( ../../../.. 
 		     ../../../../interface/vcos/${VCOS_PLATFORM}


### PR DESCRIPTION
This fixes the problem where linker flags coming from top level
makefiles or environment are no longer respected anymore. This
is for example important to pass hardening flags to the build

Signed-off-by: Khem Raj <raj.khem@gmail.com>