### PR TITLE
Escaped the * characters in the imv markdown readme

### DIFF
--- a/host_applications/linux/apps/raspicam/imv_examples/README.md
+++ b/host_applications/linux/apps/raspicam/imv_examples/README.md
@@ -13,7 +13,7 @@ raspivid -x test.imv -o test.h264
 
 We need to split the buffer first using split:
 
-split -a 4 -d -b $(((120+1)*68*4)) test.imv frame-
+split -a 4 -d -b $(((120+1)\*68\*4)) test.imv frame-
 
 Play:
 -----


### PR DESCRIPTION
The example split command reads incorrectly due to \*68\* being interpreted as italics in markdown (i.e. it is the equivalent of \<i\>68\<\/i\> in html).