### PR TITLE
Add command line option for flicker avoidance

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -933,7 +933,7 @@ void raspicamcontrol_set_defaults(RASPICAM_CAMERA_PARAMETERS *params)
    params->videoStabilisation = 0;
    params->exposureCompensation = 0;
    params->exposureMode = MMAL_PARAM_EXPOSUREMODE_AUTO;
-   params->flickerAvoidMode = MMAL_PARAM_FLICKERAVOID_AUTO;
+   params->flickerAvoidMode = MMAL_PARAM_FLICKERAVOID_OFF;
    params->exposureMeterMode = MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE;
    params->awbMode = MMAL_PARAM_AWBMODE_AUTO;
    params->imageEffect = MMAL_PARAM_IMAGEFX_NONE;

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -61,6 +61,18 @@ static XREF_T  exposure_map[] =
 
 static const int exposure_map_size = sizeof(exposure_map) / sizeof(exposure_map[0]);
 
+/// Structure to cross reference flicker avoid strings against the MMAL parameter equivalent
+
+static XREF_T  flicker_avoid_map[] =
+{
+   {"off",           MMAL_PARAM_FLICKERAVOID_OFF},
+   {"auto",          MMAL_PARAM_FLICKERAVOID_AUTO},
+   {"50hz",          MMAL_PARAM_FLICKERAVOID_50HZ},
+   {"60hz",          MMAL_PARAM_FLICKERAVOID_60HZ}
+};
+
+static const int flicker_avoid_map_size = sizeof(flicker_avoid_map) / sizeof(flicker_avoid_map[0]);
+
 /// Structure to cross reference awb strings against the MMAL parameter equivalent
 static XREF_T awb_map[] =
 {
@@ -172,7 +184,7 @@ static COMMAND_LIST  cmdline_commands[] =
    {CommandVideoStab,   "-vstab",     "vs", "Turn on video stabilisation", 0},
    {CommandEVComp,      "-ev",        "ev", "Set EV compensation - steps of 1/6 stop",  1},
    {CommandExposure,    "-exposure",  "ex", "Set exposure mode (see Notes)", 1},
-   {CommandFlicker,     "-flicker",   "fl", "Set flicker avoid mode (see Notes)", 1},
+   {CommandFlicker,     "-flicker",   "fli","Set flicker avoid mode (see Notes)", 1},
    {CommandAWB,         "-awb",       "awb","Set AWB mode (see Notes)", 1},
    {CommandImageFX,     "-imxfx",     "ifx","Set image effect (see Notes)", 1},
    {CommandColourFX,    "-colfx",     "cfx","Set colour effect (U:V)",  1},
@@ -456,7 +468,7 @@ static MMAL_PARAM_FLICKERAVOID_T flicker_avoid_mode_from_string(const char *str)
       return (MMAL_PARAM_FLICKERAVOID_T)i;
 
    vcos_log_error("Unknown flicker avoid mode: %s", str);
-   return MMAL_PARAM_FLICKERAVOID_AUTO;
+   return MMAL_PARAM_FLICKERAVOID_OFF;
 }
 
 /**

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -1228,7 +1228,6 @@ int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOS
  *   - MMAL_PARAM_FLICKERAVOID_AUTO,
  *   - MMAL_PARAM_FLICKERAVOID_50HZ,
  *   - MMAL_PARAM_FLICKERAVOID_60HZ,
- *   - MMAL_PARAM_FLICKERAVOID_MAX,
  *
  * @return 0 if successful, non-zero if any parameters out of range
  */

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.c
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.c
@@ -160,6 +160,7 @@ static const int stereo_mode_map_size = sizeof(stereo_mode_map)/sizeof(stereo_mo
 #define CommandStereoDecimate 22
 #define CommandStereoSwap  23
 #define CommandAnnotateExtras 24
+#define CommandFlicker     25
 
 static COMMAND_LIST  cmdline_commands[] =
 {
@@ -171,6 +172,7 @@ static COMMAND_LIST  cmdline_commands[] =
    {CommandVideoStab,   "-vstab",     "vs", "Turn on video stabilisation", 0},
    {CommandEVComp,      "-ev",        "ev", "Set EV compensation - steps of 1/6 stop",  1},
    {CommandExposure,    "-exposure",  "ex", "Set exposure mode (see Notes)", 1},
+   {CommandFlicker,     "-flicker",   "fl", "Set flicker avoid mode (see Notes)", 1},
    {CommandAWB,         "-awb",       "awb","Set AWB mode (see Notes)", 1},
    {CommandImageFX,     "-imxfx",     "ifx","Set image effect (see Notes)", 1},
    {CommandColourFX,    "-colfx",     "cfx","Set colour effect (U:V)",  1},
@@ -442,6 +444,22 @@ static MMAL_PARAM_EXPOSUREMODE_T exposure_mode_from_string(const char *str)
 }
 
 /**
+ * Convert string to the MMAL parameter for flicker avoid mode
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the string, or the AUTO option if no match found
+ */
+static MMAL_PARAM_FLICKERAVOID_T flicker_avoid_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, flicker_avoid_map, flicker_avoid_map_size);
+
+   if( i != -1)
+      return (MMAL_PARAM_FLICKERAVOID_T)i;
+
+   vcos_log_error("Unknown flicker avoid mode: %s", str);
+   return MMAL_PARAM_FLICKERAVOID_AUTO;
+}
+
+/**
  * Convert string to the MMAL parameter for AWB mode
  * @param str Incoming string to match
  * @return MMAL parameter matching the string, or the AUTO option if no match found
@@ -579,6 +597,11 @@ int raspicamcontrol_parse_cmdline(RASPICAM_CAMERA_PARAMETERS *params, const char
 
    case CommandExposure : // exposure mode - needs string
       params->exposureMode = exposure_mode_from_string(arg2);
+      used = 2;
+      break;
+      
+   case CommandFlicker : // flicker avoid mode - needs string
+      params->flickerAvoidMode = flicker_avoid_mode_from_string(arg2);
       used = 2;
       break;
 
@@ -783,6 +806,13 @@ void raspicamcontrol_display_help()
    {
       fprintf(stdout, ",%s", exposure_map[i].mode);
    }
+   
+   fprintf(stdout, "\n\nFlicker avoid mode options :\n%s", flicker_avoid_map[0].mode );
+
+   for (i=1;i<flicker_avoid_map_size;i++)
+   {
+      fprintf(stdout, ",%s", flicker_avoid_map[i].mode);
+   }
 
    fprintf(stdout, "\n\nAWB mode options :\n%s", awb_map[0].mode );
 
@@ -824,6 +854,7 @@ void raspicamcontrol_display_help()
 void raspicamcontrol_dump_parameters(const RASPICAM_CAMERA_PARAMETERS *params)
 {
    const char *exp_mode = raspicli_unmap_xref(params->exposureMode, exposure_map, exposure_map_size);
+   const char *fl_mode = raspicli_unmap_xref(params->flickerAvoidMode, flicker_avoid_map, flicker_avoid_map_size);
    const char *awb_mode = raspicli_unmap_xref(params->awbMode, awb_map, awb_map_size);
    const char *image_effect = raspicli_unmap_xref(params->imageEffect, imagefx_map, imagefx_map_size);
    const char *metering_mode = raspicli_unmap_xref(params->exposureMeterMode, metering_mode_map, metering_mode_map_size);
@@ -831,6 +862,7 @@ void raspicamcontrol_dump_parameters(const RASPICAM_CAMERA_PARAMETERS *params)
    fprintf(stderr, "Sharpness %d, Contrast %d, Brightness %d\n", params->sharpness, params->contrast, params->brightness);
    fprintf(stderr, "Saturation %d, ISO %d, Video Stabilisation %s, Exposure compensation %d\n", params->saturation, params->ISO, params->videoStabilisation ? "Yes": "No", params->exposureCompensation);
    fprintf(stderr, "Exposure Mode '%s', AWB Mode '%s', Image Effect '%s'\n", exp_mode, awb_mode, image_effect);
+   fprintf(stderr, "Flicker Avoid Mode '%s'\n", fl_mode);
    fprintf(stderr, "Metering Mode '%s', Colour Effect Enabled %s with U = %d, V = %d\n", metering_mode, params->colourEffects.enable ? "Yes":"No", params->colourEffects.u, params->colourEffects.v);
    fprintf(stderr, "Rotation %d, hflip %s, vflip %s\n", params->rotation, params->hflip ? "Yes":"No",params->vflip ? "Yes":"No");
    fprintf(stderr, "ROI x %lf, y %f, w %f h %f\n", params->roi.x, params->roi.y, params->roi.w, params->roi.h);
@@ -889,6 +921,7 @@ void raspicamcontrol_set_defaults(RASPICAM_CAMERA_PARAMETERS *params)
    params->videoStabilisation = 0;
    params->exposureCompensation = 0;
    params->exposureMode = MMAL_PARAM_EXPOSUREMODE_AUTO;
+   params->flickerAvoidMode = MMAL_PARAM_FLICKERAVOID_AUTO;
    params->exposureMeterMode = MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE;
    params->awbMode = MMAL_PARAM_AWBMODE_AUTO;
    params->imageEffect = MMAL_PARAM_IMAGEFX_NONE;
@@ -937,6 +970,7 @@ int raspicamcontrol_get_all_parameters(MMAL_COMPONENT_T *camera, RASPICAM_CAMERA
    params->videoStabilisation = raspicamcontrol_get_video_stabilisation(camera);
    params->exposureCompensation = raspicamcontrol_get_exposure_compensation(camera);
    params->exposureMode = raspicamcontrol_get_exposure_mode(camera);
+   params->flickerAvoidMode = raspicamcontrol_get_flicker_avoid_mode(camera);
    params->awbMode = raspicamcontrol_get_awb_mode(camera);
    params->imageEffect = raspicamcontrol_get_image_effect(camera);
    params->colourEffects = raspicamcontrol_get_colour_effect(camera);
@@ -963,6 +997,7 @@ int raspicamcontrol_set_all_parameters(MMAL_COMPONENT_T *camera, const RASPICAM_
    result += raspicamcontrol_set_video_stabilisation(camera, params->videoStabilisation);
    result += raspicamcontrol_set_exposure_compensation(camera, params->exposureCompensation);
    result += raspicamcontrol_set_exposure_mode(camera, params->exposureMode);
+   result += raspicamcontrol_set_flicker_avoid_mode(camera, params->flickerAvoidMode);
    result += raspicamcontrol_set_metering_mode(camera, params->exposureMeterMode);
    result += raspicamcontrol_set_awb_mode(camera, params->awbMode);
    result += raspicamcontrol_set_awb_gains(camera, params->awb_gains_r, params->awb_gains_b);
@@ -1182,6 +1217,29 @@ int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOS
       return 1;
 
    return mmal_status_to_int(mmal_port_parameter_set(camera->control, &exp_mode.hdr));
+}
+
+
+/**
+ * Set flicker avoid mode for images
+ * @param camera Pointer to camera component
+ * @param mode Exposure mode to set from
+ *   - MMAL_PARAM_FLICKERAVOID_OFF,
+ *   - MMAL_PARAM_FLICKERAVOID_AUTO,
+ *   - MMAL_PARAM_FLICKERAVOID_50HZ,
+ *   - MMAL_PARAM_FLICKERAVOID_60HZ,
+ *   - MMAL_PARAM_FLICKERAVOID_MAX,
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_flicker_avoid_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_FLICKERAVOID_T mode)
+{
+   MMAL_PARAMETER_FLICKERAVOID_T fl_mode = {{MMAL_PARAMETER_FLICKER_AVOID,sizeof(fl_mode)}, mode};
+
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &fl_mode.hdr));
 }
 
 

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.h
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.h
@@ -173,26 +173,6 @@ typedef enum {
 } ZOOM_COMMAND_T;
 
 
-
-/// Structure to cross reference flicker avoid strings against the MMAL parameter equivalent
-///
-/// TODO: brought here due to duplication between two .c files (RapiCamControl and RaspiVid).
-/// Considered moving it to a separate header, but since I don't know architectural plans
-/// for command line parsing, did not. Ideas: create ArgumentMMALmaps.h and move all
-/// XREF_T structures there? Or bring them here? Either way, here it's not duplicated.
-
-static XREF_T  flicker_avoid_map[] =
-{
-   {"off",           MMAL_PARAM_FLICKERAVOID_OFF},
-   {"auto",          MMAL_PARAM_FLICKERAVOID_AUTO},
-   {"50hz",          MMAL_PARAM_FLICKERAVOID_50HZ},
-   {"60hz",          MMAL_PARAM_FLICKERAVOID_60HZ}
-};
-
-static const int flicker_avoid_map_size = sizeof(flicker_avoid_map) / sizeof(flicker_avoid_map[0]);
-
-
-
 void raspicamcontrol_check_configuration(int min_gpu_mem);
 
 int raspicamcontrol_parse_cmdline(RASPICAM_CAMERA_PARAMETERS *params, const char *arg1, const char *arg2);

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.h
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.h
@@ -29,6 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef RASPICAMCONTROL_H_
 #define RASPICAMCONTROL_H_
 
+#include "RaspiCLI.h" // get type XREF_T
+
 /* Various parameters
  *
  * Exposure Mode
@@ -45,6 +47,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             MMAL_PARAM_EXPOSUREMODE_FIXEDFPS,
             MMAL_PARAM_EXPOSUREMODE_ANTISHAKE,
             MMAL_PARAM_EXPOSUREMODE_FIREWORKS,
+ *
+ * Flicker Avoid Mode
+ *          MMAL_PARAM_FLICKERAVOID_OFF,
+            MMAL_PARAM_FLICKERAVOID_AUTO,
+            MMAL_PARAM_FLICKERAVOID_50HZ,
+            MMAL_PARAM_FLICKERAVOID_60HZ,
  *
  * AWB Mode
  *          MMAL_PARAM_AWBMODE_OFF,
@@ -142,6 +150,7 @@ typedef struct raspicam_camera_parameters_s
    MMAL_PARAM_IMAGEFX_T imageEffect;
    MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imageEffectsParameters;
    MMAL_PARAM_COLOURFX_T colourEffects;
+   MMAL_PARAM_FLICKERAVOID_T flickerAvoidMode;
    int rotation;              /// 0-359
    int hflip;                 /// 0 or 1
    int vflip;                 /// 0 or 1
@@ -162,6 +171,26 @@ typedef struct raspicam_camera_parameters_s
 typedef enum {
     ZOOM_IN, ZOOM_OUT, ZOOM_RESET
 } ZOOM_COMMAND_T;
+
+
+
+/// Structure to cross reference flicker avoid strings against the MMAL parameter equivalent
+///
+/// TODO: brought here due to duplication between two .c files (RapiCamControl and RaspiVid).
+/// Considered moving it to a separate header, but since I don't know architectural plans
+/// for command line parsing, did not. Ideas: create ArgumentMMALmaps.h and move all
+/// XREF_T structures there? Or bring them here? Either way, here it's not duplicated.
+
+static XREF_T  flicker_avoid_map[] =
+{
+   {"off",           MMAL_PARAM_FLICKERAVOID_OFF},
+   {"auto",          MMAL_PARAM_FLICKERAVOID_AUTO},
+   {"50hz",          MMAL_PARAM_FLICKERAVOID_50HZ},
+   {"60hz",          MMAL_PARAM_FLICKERAVOID_60HZ}
+};
+
+static const int flicker_avoid_map_size = sizeof(flicker_avoid_map) / sizeof(flicker_avoid_map[0]);
+
 
 
 void raspicamcontrol_check_configuration(int min_gpu_mem);
@@ -188,6 +217,7 @@ int raspicamcontrol_set_metering_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOS
 int raspicamcontrol_set_video_stabilisation(MMAL_COMPONENT_T *camera, int vstabilisation);
 int raspicamcontrol_set_exposure_compensation(MMAL_COMPONENT_T *camera, int exp_comp);
 int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOSUREMODE_T mode);
+int raspicamcontrol_set_flicker_avoid_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_FLICKERAVOID_T mode);
 int raspicamcontrol_set_awb_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_AWBMODE_T awb_mode);
 int raspicamcontrol_set_awb_gains(MMAL_COMPONENT_T *camera, float r_gain, float b_gain);
 int raspicamcontrol_set_imageFX(MMAL_COMPONENT_T *camera, MMAL_PARAM_IMAGEFX_T imageFX);
@@ -214,9 +244,12 @@ int raspicamcontrol_get_video_stabilisation(MMAL_COMPONENT_T *camera);
 int raspicamcontrol_get_exposure_compensation(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_THUMBNAIL_CONFIG_T raspicamcontrol_get_thumbnail_parameters(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_EXPOSUREMODE_T raspicamcontrol_get_exposure_mode(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_FLICKERAVOID_T raspicamcontrol_get_flicker_avoid_mode(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_AWBMODE_T raspicamcontrol_get_awb_mode(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_IMAGEFX_T raspicamcontrol_get_imageFX(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_COLOURFX_T raspicamcontrol_get_colourFX(MMAL_COMPONENT_T *camera);
+
+
 
 
 #endif /* RASPICAMCONTROL_H_ */

--- a/host_applications/linux/apps/raspicam/RaspiCamControl.h
+++ b/host_applications/linux/apps/raspicam/RaspiCamControl.h
@@ -29,8 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef RASPICAMCONTROL_H_
 #define RASPICAMCONTROL_H_
 
-#include "RaspiCLI.h" // get type XREF_T
-
 /* Various parameters
  *
  * Exposure Mode

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2711,11 +2711,6 @@ int main(int argc, const char **argv)
             {
                state.callback_data.imv_file_handle = stdout;
             }
-            else if (state.imv_filename[0] == '!')
-            {
-	       // TODO: if this occurs, we should suppress writing error and status messages to stderr.
-               state.callback_data.imv_file_handle = stderr;
-            }
             else
             {
                state.callback_data.imv_file_handle = open_filename(&state, state.imv_filename);

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2698,11 +2698,6 @@ int main(int argc, const char **argv)
             {
                state.callback_data.imv_file_handle = stdout;
             }
-            else if (state.imv_filename[0] == '!')
-            {
-	       // TODO: if this occurs, we should suppress writing error and status messages to stderr.
-               state.callback_data.imv_file_handle = stderr;
-            }
             else
             {
                state.callback_data.imv_file_handle = open_filename(&state, state.imv_filename);

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -323,7 +323,6 @@ static void display_valid_parameters(char *app_name);
 #define CommandRaw          32
 #define CommandRawFormat    33
 #define CommandNetListen    34
-#define CommandFlickerAvoid 35
 
 static COMMAND_LIST cmdline_commands[] =
 {
@@ -339,7 +338,6 @@ static COMMAND_LIST cmdline_commands[] =
    { CommandTimeout,       "-timeout",    "t",  "Time (in ms) to capture for. If not specified, set to 5s. Zero to disable", 1 },
    { CommandDemoMode,      "-demo",       "d",  "Run a demo mode (cycle through range of camera options, no capture)", 1},
    { CommandFramerate,     "-framerate",  "fps","Specify the frames per second to record", 1},
-   { CommandFlickerAvoid,  "-flicker",    "fl", "Select flicker avoid mode (off, auto, 50hz, 60hz). Default 'auto'", 0},
    { CommandPreviewEnc,    "-penc",       "e",  "Display preview image *after* encoding (shows compression artifacts)", 0},
    { CommandIntraPeriod,   "-intra",      "g",  "Specify the intra refresh period (key frame rate/GoP size). Zero to produce an initial I-frame and then just P-frames.", 1},
    { CommandProfile,       "-profile",    "pf", "Specify H264 profile to use for encoding", 1},
@@ -633,17 +631,6 @@ static int parse_cmdline(int argc, const char **argv, RASPIVID_STATE *state)
          }
          else
             valid = 0;
-         break;
-      }
-      
-      case CommandFlickerAvoid: // flicker avoid mode
-      {
-         state->camera_parameters.flickerAvoidMode = raspicli_map_xref(argv[i + 1], flicker_avoid_map, flicker_avoid_map_size);
-
-         if( state->camera_parameters.flickerAvoidMode == -1)
-            state->camera_parameters.flickerAvoidMode = MMAL_PARAM_FLICKERAVOID_AUTO;
-
-         i++;
          break;
       }
       
@@ -2710,6 +2697,11 @@ int main(int argc, const char **argv)
             if (state.imv_filename[0] == '-')
             {
                state.callback_data.imv_file_handle = stdout;
+            }
+            else if (state.imv_filename[0] == '!')
+            {
+	       // TODO: if this occurs, we should suppress writing error and status messages to stderr.
+               state.callback_data.imv_file_handle = stderr;
             }
             else
             {


### PR DESCRIPTION
This change enables a user to run "raspivid" with various flicker avoidance modes. It was previously discussed at "https://www.raspberrypi.org/forums/viewtopic.php?f=43&t=159115", where "6by9" mentioned the existence of the MMAL option and "cpunks" (me) wrote the patch.

An aspect from which this patch might need improving, is how command lines are parsed and where "static XREF_T flicker_avoid_map[]" is located. To avoid duplication, I placed it in "RaspiCamControl.h", but since I don't know architectural plans for command line parsing, I might have placed it inconveniently for others.