### PR TITLE
pkgconfig: commit to new library naming scheme

### DIFF
--- a/pkgconfig/egl.pc.in
+++ b/pkgconfig/egl.pc.in
@@ -1,13 +1,1 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
-
-Name: EGL
-Description: Fake EGL package for RPi
-Version: 10
-Requires: bcm_host
-Libs: -L${libdir} -lEGL -lGLESv2 -lbcm_host -lvchostif
-Cflags: -I${includedir} -I${includedir}/interface/vmcs_host/linux \
-        -I${includedir}/interface/vcos/pthreads
-
+brcmegl.pc.in

--- a/pkgconfig/glesv2.pc.in
+++ b/pkgconfig/glesv2.pc.in
@@ -1,12 +1,1 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
-
-Name: GLESv2
-Description: Fake GL ES 2 package for RPi
-Version: 10
-Requires: bcm_host
-Libs: -L${libdir} -lGLESv2
-Cflags: -I${includedir}
-
+brcmglesv2.pc.in

--- a/pkgconfig/vg.pc.in
+++ b/pkgconfig/vg.pc.in
@@ -1,11 +1,1 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
-
-Name: OpenVG
-Description: Fake OpenVG package for RPi
-Version: 10
-Requires: bcm_host
-Libs: -L${libdir} -lOpenVG
-Cflags: -I${includedir}
+brcmvg.pc.in


### PR DESCRIPTION
Recent firmware images have deprecated the original-named libraries
(libEGL, libGLESv1_CM, libGLESv2, libOpenVG). This means that the
corresponding dummy .pc files will present issues if installed.

Instead, use the proper library names via symlink.

These files will only be detected when the variable
"PKG_CONFIG_PATH=/opt/vc/lib/pkgconfig" is set manually.

--
This commit is related to this issue: https://github.com/raspberrypi/firmware/issues/857