### PR TITLE
dtoverlay: no longer require user "pi"

### DIFF
--- a/host_applications/linux/apps/dtoverlay/dtoverlay-post
+++ b/host_applications/linux/apps/dtoverlay/dtoverlay-post
@@ -4,7 +4,7 @@ if [ "$DISPLAY" == "" ]; then
 fi
 CMD="which lxpanelctl >/dev/null 2>&1 && lxpanelctl alsastart >/dev/null"
 if [ $(id -u) -eq 0 ]; then
-        exec su $(id -un) -c "$CMD"
+        exec su $(who am i | cut -d' ' -f1) -c "$CMD"
 else
         exec $CMD
 fi

--- a/host_applications/linux/apps/dtoverlay/dtoverlay-post
+++ b/host_applications/linux/apps/dtoverlay/dtoverlay-post
@@ -3,8 +3,8 @@ if [ "$DISPLAY" == "" ]; then
 	export DISPLAY=":0.0"
 fi
 CMD="which lxpanelctl >/dev/null 2>&1 && lxpanelctl alsastart >/dev/null"
-if [ $EUID -eq 0 ]; then
-        exec su pi -c "$CMD"
+if [ $(id -u) -eq 0 ]; then
+        exec su $(id -un) -c "$CMD"
 else
         exec $CMD
 fi

--- a/host_applications/linux/apps/dtoverlay/dtoverlay-pre
+++ b/host_applications/linux/apps/dtoverlay/dtoverlay-pre
@@ -4,7 +4,7 @@ if [ "$DISPLAY" == "" ]; then
 fi
 CMD="which lxpanelctl >/dev/null 2>&1 && lxpanelctl alsastop >/dev/null"
 if [ $(id -u) -eq 0 ]; then
-	exec su $(id -un) -c "$CMD"
+	exec su $(who am i | cut -d' ' -f1) -c "$CMD"
 else
 	exec $CMD
 fi

--- a/host_applications/linux/apps/dtoverlay/dtoverlay-pre
+++ b/host_applications/linux/apps/dtoverlay/dtoverlay-pre
@@ -3,8 +3,8 @@ if [ "$DISPLAY" == "" ]; then
 	export DISPLAY=":0.0"
 fi
 CMD="which lxpanelctl >/dev/null 2>&1 && lxpanelctl alsastop >/dev/null"
-if [ $EUID -eq 0 ]; then
-	exec su pi -c "$CMD"
+if [ $(id -u) -eq 0 ]; then
+	exec su $(id -un) -c "$CMD"
 else
 	exec $CMD
 fi


### PR DESCRIPTION
also $(id -u) seems more reliable than $EUID which can be overwritten by the user