### PR TITLE
mmal_wrapper: Fix a short allocation for pools and queues

### DIFF
--- a/interface/mmal/util/mmal_component_wrapper.c
+++ b/interface/mmal/util/mmal_component_wrapper.c
@@ -151,7 +151,7 @@ MMAL_STATUS_T mmal_wrapper_create(MMAL_WRAPPER_T **ctx, const char *name)
    if (status != MMAL_SUCCESS)
       return status;
 
-   extra_size = (component->input_num + component->output_num * 2) * sizeof(*private);
+   extra_size = (component->input_num * sizeof(MMAL_POOL_T*)) + (component->output_num * (sizeof(MMAL_POOL_T*) + sizeof(MMAL_QUEUE_T*)));
    private = vcos_calloc(1, sizeof(*private) + extra_size, "mmal wrapper");
    if (!private)
    {

--- a/interface/mmal/util/mmal_component_wrapper.c
+++ b/interface/mmal/util/mmal_component_wrapper.c
@@ -151,7 +151,7 @@ MMAL_STATUS_T mmal_wrapper_create(MMAL_WRAPPER_T **ctx, const char *name)
    if (status != MMAL_SUCCESS)
       return status;
 
-   extra_size = (component->input_num + component->output_num) * 2;
+   extra_size = (component->input_num + component->output_num * 2) * sizeof(*private);
    private = vcos_calloc(1, sizeof(*private) + extra_size, "mmal wrapper");
    if (!private)
    {


### PR DESCRIPTION
There is a bug in MMAL wrapper code that is because of a short allocation for pools and queues. The bug corrupts stack, so some programs exit with error.

Program to reproduce: https://github.com/Terminus-IMRC/mmal-wrapper-issue-short-allocation

Please merge this to your repo.

Thanks.