### PR TITLE
Include stdarg.h in dtoverlay.h

### DIFF
--- a/helpers/dtoverlay/dtoverlay.h
+++ b/helpers/dtoverlay/dtoverlay.h
@@ -28,6 +28,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef DTOVERLAY_H
 #define DTOVERLAY_H
 
+#include <stdarg.h>
+
 #define BE4(x) ((x)>>24)&0xff, ((x)>>16)&0xff, ((x)>>8)&0xff, ((x)>>0)&0xff
 #define GETBE4(p, off) ((((unsigned char *)p)[off + 0]<<24) + (((unsigned char *)p)[off + 1]<<16) + \
                   (((unsigned char *)p)[off + 2]<<8) + (((unsigned char *)p)[off + 3]<<0))


### PR DESCRIPTION
Fixes a buildroot build error:
```
/home/serge/noobs/buildroot/output/build/rpi-userland-bc3c52a51315399a9f31ed24049eb4bc81fd1c60/helpers/dtoverlay/dtoverlay.h:74:54: error: unknown type name ‘va_list’
                                     const char *fmt, va_list args);
                                                      ^
/home/serge/noobs/buildroot/output/build/rpi-userland-bc3c52a51315399a9f31ed24049eb4bc81fd1c60/helpers/dtoverlay/dtoverlay.h:189:33: error: unknown type name ‘DTOVERLAY_LOGGING_FUNC’
 void dtoverlay_set_logging_func(DTOVERLAY_LOGGING_FUNC *func);
                                 ^
[ 37%] make[3]: *** [host_applications/linux/apps/dtmerge/CMakeFiles/dtmerge.dir/dtmerge.c.o] Error 1
```