### PR TITLE
Verbose is not disabled when capture is streamed

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1958,12 +1958,7 @@ int main(int argc, const char **argv)
                if (state.filename)
                {
                   if (state.filename[0] == '-')
-                  {
                      output_file = stdout;
-
-                     // Ensure we don't upset the output stream with diagnostics/info
-                     state.verbose = 0;
-                  }
                   else
                   {
                      vcos_assert(use_filename == NULL && final_filename == NULL);


### PR DESCRIPTION
Verbose was being disabled when a capture is sent to stdout, but verbose is sent to stderr, so there is no need to disable it.