### PR TITLE
Verbose is not disabled when capture is streamed #2

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1958,7 +1958,9 @@ int main(int argc, const char **argv)
                if (state.filename)
                {
                   if (state.filename[0] == '-')
+		  {
                      output_file = stdout;
+		  }
                   else
                   {
                      vcos_assert(use_filename == NULL && final_filename == NULL);

--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1958,12 +1958,7 @@ int main(int argc, const char **argv)
                if (state.filename)
                {
                   if (state.filename[0] == '-')
-                  {
                      output_file = stdout;
-
-                     // Ensure we don't upset the output stream with diagnostics/info
-                     state.verbose = 0;
-                  }
                   else
                   {
                      vcos_assert(use_filename == NULL && final_filename == NULL);

--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1958,9 +1958,9 @@ int main(int argc, const char **argv)
                if (state.filename)
                {
                   if (state.filename[0] == '-')
-		  {
+                  {
                      output_file = stdout;
-		  }
+                  }
                   else
                   {
                      vcos_assert(use_filename == NULL && final_filename == NULL);

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -1323,9 +1323,6 @@ int main(int argc, const char **argv)
                if (state.filename[0] == '-')
                {
                   output_file = stdout;
-
-                  // Ensure we don't upset the output stream with diagnostics/info
-                  state.verbose = 0;
                }
                else
                {

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -956,12 +956,6 @@ static int parse_cmdline(int argc, const char **argv, RASPIVID_STATE *state)
       return 1;
    }
 
-   // Always disable verbose if output going to stdout
-   if (state->filename && state->filename[0] == '-')
-   {
-      state->verbose = 0;
-   }
-
    return 0;
 }
 
@@ -2709,9 +2703,6 @@ int main(int argc, const char **argv)
             if (state.filename[0] == '-')
             {
                state.callback_data.file_handle = stdout;
-
-               // Ensure we don't upset the output stream with diagnostics/info
-               state.verbose = 0;
             }
             else
             {

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -606,12 +606,6 @@ static int parse_cmdline(int argc, const char **argv, RASPIVIDYUV_STATE *state)
       return 1;
    }
 
-   // Always disable verbose if output going to stdout
-   if (state->filename && state->filename[0] == '-')
-   {
-      state->verbose = 0;
-   }
-
    return 0;
 }
 
@@ -1469,9 +1463,6 @@ int main(int argc, const char **argv)
             if (state.filename[0] == '-')
             {
                state.callback_data.file_handle = stdout;
-
-               // Ensure we don't upset the output stream with diagnostics/info
-               state.verbose = 0;
             }
             else
             {


### PR DESCRIPTION
RaspiStillYUV.c had the same issue as RaspiStill.c (#450)
Same fix is applied to RaspiStillYUV.c, and braces are added back to RaspiStill.c for consistency.