### PR TITLE
MMAL: Use calloc on some structures to make Valgrind happy

### DIFF
--- a/interface/mmal/core/mmal_format.c
+++ b/interface/mmal/core/mmal_format.c
@@ -52,7 +52,7 @@ MMAL_ES_FORMAT_T *mmal_format_alloc(void)
 {
    MMAL_ES_FORMAT_PRIVATE_T *private;
 
-   private = vcos_malloc(sizeof(*private), "mmal format");
+   private = vcos_calloc(1, sizeof(*private), "mmal format");
    if(!private) return 0;
    memset(private, 0, sizeof(*private));
 
@@ -169,7 +169,7 @@ MMAL_STATUS_T mmal_format_extradata_alloc(MMAL_ES_FORMAT_T *format, unsigned int
    if(private->extradata_size < size)
    {
       if(private->extradata) vcos_free(private->extradata);
-      private->extradata = vcos_malloc(size, "mmal format extradata");
+      private->extradata = vcos_calloc(1, size, "mmal format extradata");
       if(!private->extradata)
          return MMAL_ENOMEM;
       private->extradata_size = size;

--- a/interface/mmal/core/mmal_port.c
+++ b/interface/mmal/core/mmal_port.c
@@ -250,7 +250,7 @@ MMAL_PORT_T **mmal_ports_alloc(MMAL_COMPONENT_T *component, unsigned int ports_n
    MMAL_PORT_T **ports;
    unsigned int i;
 
-   ports = vcos_malloc(sizeof(MMAL_PORT_T *) * ports_num, "mmal ports");
+   ports = vcos_calloc(1, sizeof(MMAL_PORT_T *) * ports_num, "mmal ports");
    if (!ports)
       return 0;
 

--- a/interface/mmal/vc/mmal_vc_api.c
+++ b/interface/mmal/vc/mmal_vc_api.c
@@ -1268,7 +1268,7 @@ static uint8_t *mmal_vc_port_payload_alloc(MMAL_PORT_T *port, uint32_t payload_s
    else
    {
       /* Allocate conventional memory */
-      ret = vcos_malloc(payload_size, "mmal_vc_port payload");
+      ret = vcos_calloc(1, payload_size, "mmal_vc_port payload");
       if (!ret)
       {
          LOG_ERROR("could not allocate %i bytes", (int)payload_size);


### PR DESCRIPTION
Valgrind complains that various bits of MMAL structures
are used before initialised. They aren't, but are filled
in by the VPU or kernel so are out of sight of Valgrind.

Using calloc for a couple of structures has minimal overhead
and shuts Valgrind up.