### PR TITLE
pkgconfig: vcsm: Add -lvcos to Libs

### DIFF
--- a/pkgconfig/vcsm.pc.in
+++ b/pkgconfig/vcsm.pc.in
@@ -6,5 +6,5 @@ includedir=${prefix}/include
 Name: VCSM
 Description: VideoCore Shared Memory library for RPi
 Version: 1
-Libs: -L${libdir} -lvcsm
+Libs: -L${libdir} -lvcsm -lvcos
 Cflags: -I${includedir}


### PR DESCRIPTION
`libvcsm.so` is linked with vcos in https://github.com/raspberrypi/userland/blob/master/host_applications/linux/libs/sm/CMakeLists.txt#L15 , so changed to specify it in pkgconfig file.