### PR TITLE
host_apps: Add --no-as-needed to stop libmmal_vc_client being dropped

### DIFF
--- a/host_applications/android/apps/vidtex/CMakeLists.txt
+++ b/host_applications/android/apps/vidtex/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 
 SET(COMPILE_DEFINITIONS -Werror -Wall)
+
+# Set --no-as-needed to stop the linker discarding mmal_vc_client
+# as it can't see that the constructor registers a load of functionality
+# with the MMAL core.
+SET( CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed" )
+
 include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
 
 set (VIDTEX_SOURCES

--- a/host_applications/linux/apps/hello_pi/hello_mmal_encode/Makefile
+++ b/host_applications/linux/apps/hello_pi/hello_mmal_encode/Makefile
@@ -1,6 +1,10 @@
 OBJS=mmal_encode.o
 BIN=hello_mmal_encode.bin
 LDFLAGS+=-lmmal -lmmal_core -lmmal_components -lmmal_util -lmmal_vc_client
+# Set --no-as-needed to stop the linker discarding mmal_vc_client
+# as it can't see that the constructor registers a load of functionality
+# with the MMAL core.
+LDFLAGS+=-Wl,--no-as-needed
 
 include ../Makefile.include
 

--- a/host_applications/linux/apps/raspicam/CMakeLists.txt
+++ b/host_applications/linux/apps/raspicam/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 SET(COMPILE_DEFINITIONS -Werror)
 
+# Set --no-as-needed to stop the linker discarding mmal_vc_client
+# as it can't see that the constructor registers a load of functionality
+# with the MMAL core.
+SET( CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed" )
+
 include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/bcm_host/include)
 include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/apps/raspicam/)
 include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/sm)


### PR DESCRIPTION
Some versions of GCC have --as-needed turned on by default.
The binding of libmmal_vc_client is such that the constructor
registers the supported components with the MMAL core, and nothing
calls into it directly. The linker can't tell this, decides
it is unused, and promptly drops it as a dependency - cue no
VideoCore components.

Adding --no-as-needed means that the linker leaves it alone.
It's not nice, but there doesn't appear to be a better solution.

See #178.