### PR TITLE
RaspiVid: Return an error if the overall encode exceeds level 4.2

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2153,6 +2153,7 @@ static MMAL_STATUS_T create_encoder_component(RASPIVID_STATE *state)
          else
          {
             vcos_log_error("Too many macroblocks/s requested");
+            status = MMAL_EINVAL;
             goto error;
          }
       }


### PR DESCRIPTION
The error handling forgot to set an error status, so main continued
on and then seg faulted due to no encoder component.

Fixes #464.