### PR TITLE
khronos: backport EGLuint64KHR typedef from recent Khronos

### DIFF
--- a/interface/khronos/include/EGL/eglext.h
+++ b/interface/khronos/include/EGL/eglext.h
@@ -190,6 +190,10 @@ typedef EGLBoolean (EGLAPIENTRYP PFNEGLSIGNALSYNCKHRPROC) (EGLDisplay dpy, EGLSy
 typedef EGLBoolean (EGLAPIENTRYP PFNEGLGETSYNCATTRIBKHRPROC) (EGLDisplay dpy, EGLSyncKHR sync, EGLint attribute, EGLint *value);
 #endif
 
+#ifndef EGL_KHR_uint64_typedef
+#define EGL_KHR_uint64_typedef 1
+typedef khronos_uint64_t EGLuint64KHR;
+#endif /* EGL_KHR_uint64_typedef */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The newer `gstreamer1.0-plugins-base` package version `1.14` uses `EGL_EXT_image_dma_buf_import`,
which expects the `EGLuint64KHR` typedef that is present in recent versions of Khronos.
However, the older version included in userland does not provide it.

This patch backports the missing typedef from recent Khronos into userland.
See: <https://www.khronos.org/registry/EGL/api/EGL/eglext.h>