### PR TITLE
glxx_client: Fix glMapBufferOES with GL_STREAM_DRAW

### DIFF
--- a/interface/khronos/glxx/glxx_client.c
+++ b/interface/khronos/glxx/glxx_client.c
@@ -382,7 +382,7 @@ GL_API void GL_APIENTRY glBufferData (GLenum target, GLsizeiptr size, const GLvo
       {
          if( ((target == GL_ARRAY_BUFFER && state->bound_buffer.array != 0) ||
               (target == GL_ELEMENT_ARRAY_BUFFER && state->bound_buffer.element_array != 0)) &&
-             (usage ==  GL_STATIC_DRAW || usage == GL_DYNAMIC_DRAW) &&
+             (usage ==  GL_STATIC_DRAW || usage == GL_DYNAMIC_DRAW || (IS_OPENGLES_20(thread) && usage == GL_STREAM_DRAW)) &&
              size >=0
            )
          {


### PR DESCRIPTION
glMapBufferOES fails if the usage hint passed to glBufferData was
GL_STREAM_DRAW because glBufferData does not initialise the cached copy
of the buffer size.

The usage hint doesn't make any functional difference with these
functions and GL_STREAM_DRAW was added in GLES 2.0 so this looks like
an old check which was never updated.

Fixes #246