### PR TITLE
glxx_client: Fix glGetBufferParameteriv GL_BUFFER_SIZE

### DIFF
--- a/interface/khronos/glxx/glxx_client.c
+++ b/interface/khronos/glxx/glxx_client.c
@@ -2107,6 +2107,7 @@ GL_API void GL_APIENTRY glGetBufferParameteriv (GLenum target, GLenum pname, GLi
          {
             GLXX_CLIENT_STATE_T *state = GLXX_GET_CLIENT_STATE(thread);
             GLXX_BUFFER_INFO_T buffer;
+            glxx_buffer_info_get(state, target, &buffer);
             buffer.cached_size = params[0];
             glxx_buffer_info_set(state, target, &buffer);
          }


### PR DESCRIPTION
glGetBufferParameteriv updates the client side cached copy of the
buffer_size. However, when it updated the cache it by calling
glxx_buffer_info_set it trashed the mapped_pointer and mapped_size
values because they are in the same structure as the cached_size but
this was being allocated on the stack.

The trampled mapped_pointer / mapped_size could cause crashes or invalid
buffer data to be uploaded.

Change to read the current cached value and then modify just the
cached_size preserving whatever was in the cache before.

Fixes #323

Signed-off-by: Tim Gover <tim.gover@raspberrypi.org>