### PR TITLE
Fixed up initial timelapse delay

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -106,6 +106,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FRAME_NEXT_SIGNAL        5
 #define FRAME_NEXT_IMMEDIATELY   6
 
+/// Amount of time before first image taken to allow settling of
+/// exposure etc. in milliseconds.
+#define CAMERA_SETTLE_TIME       1000
 
 int mmal_status_to_int(MMAL_STATUS_T status);
 static void signal_handler(int signal_number);
@@ -1601,7 +1604,7 @@ static int wait_for_next_frame(RASPISTILL_STATE *state, int *frame)
 
       if (next_frame_ms == -1)
       {
-         vcos_sleep(state->timelapse);
+         vcos_sleep(CAMERA_SETTLE_TIME);
 
          // Update our current time after the sleep
          current_time =  vcos_getmicrosecs64()/1000;
@@ -1667,7 +1670,7 @@ static int wait_for_next_frame(RASPISTILL_STATE *state, int *frame)
       // This could probably be tuned down.
       // First frame has a much longer delay to ensure we get exposure to a steady state
       if (*frame == 0)
-         vcos_sleep(1000);
+         vcos_sleep(CAMERA_SETTLE_TIME);
       else
          vcos_sleep(30);
 

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -100,6 +100,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FRAME_NEXT_SIGNAL        5
 #define FRAME_NEXT_IMMEDIATELY   6
 
+#define CAMERA_SETTLE_TIME       1000
+
 int mmal_status_to_int(MMAL_STATUS_T status);
 static void signal_handler(int signal_number);
 
@@ -1034,7 +1036,7 @@ static int wait_for_next_frame(RASPISTILLYUV_STATE *state, int *frame)
 
       if (next_frame_ms == -1)
       {
-         vcos_sleep(state->timelapse);
+         vcos_sleep(CAMERA_SETTLE_TIME);
 
          // Update our current time after the sleep
          current_time =  vcos_getmicrosecs64()/1000;
@@ -1100,7 +1102,7 @@ static int wait_for_next_frame(RASPISTILLYUV_STATE *state, int *frame)
       // This could probably be tuned down.
       // First frame has a much longer delay to ensure we get exposure to a steady state
       if (*frame == 0)
-         vcos_sleep(1000);
+         vcos_sleep(CAMERA_SETTLE_TIME);
       else
          vcos_sleep(30);
 


### PR DESCRIPTION
When in timelapse mode, the delay before the first shot
was the timelapse value. However, if a low value is set
this does not give enough time for the AE etc to settle.

In addition, the first image was only taken after the
first delay, rather than immediately which is what would
be expected. So a 5minute timelapse delay meant the 1st
image was only taken after 5 minutes.

The patch sets the delay for the first image capture to
be a constant value, 1000ms. So always time for the AE etc
to settle.

Fixes: #429, #473