### PR TITLE
Raspicam tweaks

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -246,7 +246,9 @@ static struct
    {"jpg", MMAL_ENCODING_JPEG},
    {"bmp", MMAL_ENCODING_BMP},
    {"gif", MMAL_ENCODING_GIF},
-   {"png", MMAL_ENCODING_PNG}
+   {"png", MMAL_ENCODING_PNG},
+   {"ppm", MMAL_ENCODING_PPM},
+   {"tga", MMAL_ENCODING_TGA}
 };
 
 static int encoding_xref_size = sizeof(encoding_xref) / sizeof(encoding_xref[0]);

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -1625,7 +1625,7 @@ error:
          fprintf(stderr, "Closing down\n");
 
       // Disable all our ports that are not handled by connections
-      check_disable_port(camera_still_port);
+      check_disable_port(camera_video_port);
 
       if (state.preview_parameters.wantPreview && state.preview_connection)
          mmal_connection_destroy(state.preview_connection);


### PR DESCRIPTION
Support for TGA and PPM encoders to Raspistill

Bug fix to RaspiVidYuv to shut down the correct output port before closing file handles.