### PR TITLE
mmal: Add KEEP_PORT_FORMATS flag to mmal connection

### DIFF
--- a/interface/mmal/util/mmal_connection.c
+++ b/interface/mmal/util/mmal_connection.c
@@ -191,14 +191,17 @@ MMAL_STATUS_T mmal_connection_create(MMAL_CONNECTION_T **cx,
 
    connection->time_setup = vcos_getmicrosecs();
 
-   /* Set the format of the input port to match the output one */
-   status = mmal_format_full_copy(in->format, out->format);
-   if (status == MMAL_SUCCESS)
-      status = mmal_port_format_commit(in);
-   if (status != MMAL_SUCCESS)
+   if (!(connection->flags & MMAL_CONNECTION_FLAG_KEEP_PORT_FORMATS))
    {
-      LOG_ERROR("format not set on input port");
-      goto error;
+      /* Set the format of the input port to match the output one */
+      status = mmal_format_full_copy(in->format, out->format);
+      if (status == MMAL_SUCCESS)
+         status = mmal_port_format_commit(in);
+      if (status != MMAL_SUCCESS)
+      {
+         LOG_ERROR("format not set on input port");
+         goto error;
+      }
    }
 
    /* In pass-through mode we need to propagate the buffer requirements of the

--- a/interface/mmal/util/mmal_connection.h
+++ b/interface/mmal/util/mmal_connection.h
@@ -100,6 +100,8 @@ extern "C" {
  * the connection itself but is used by the the graph utility to specify that
  * the buffer should be sent to the input port from with the port callback. */
 #define MMAL_CONNECTION_FLAG_DIRECT 0x10
+/** Specify that the connection should not modify the port formats. */
+#define MMAL_CONNECTION_FLAG_KEEP_PORT_FORMATS 0x20
 /* @} */
 
 /** Forward type definition for a connection */


### PR DESCRIPTION
There's a slightly quirky use case with deinterlacing.
Interlaced YUV420 is line interleaved, so chroma line 1
is that for luma lines 1&3, and chroma line 2 is for luma lines 2&4.
If you pass such a frame into a standard component (eg the ISP), it
messes up the chroma by assuming chroma line 1 is for luma lines 1&2.

If you pass it into the ISP as double width by half height then the
chroma subsampling behaves correctly. Normally that precludes using
a mmal_connection as that will copy the port format from output
to input. Setting this new flag skips that stage and makes it the
client's responsibilty to set both port formats appropriately.