### PR TITLE
MMAL & RaspiStillYuv updates

### DIFF
--- a/interface/mmal/core/mmal_port.c
+++ b/interface/mmal/core/mmal_port.c
@@ -724,7 +724,8 @@ MMAL_STATUS_T mmal_port_send_buffer(MMAL_PORT_T *port,
              buffer ? (int)buffer->length : 0);
 #endif
 
-   if (!buffer->data && !(port->capabilities & MMAL_PORT_CAPABILITY_PASSTHROUGH))
+   if (buffer->alloc_size && !buffer->data &&
+       !(port->capabilities & MMAL_PORT_CAPABILITY_PASSTHROUGH))
    {
       LOG_ERROR("%s(%p) received invalid buffer header", port->name, port);
       return MMAL_EINVAL;


### PR DESCRIPTION
Two unrelated changes.

RaspiStillYuv supported RGB24 but not BGR24. Add it.

Cherry-picking a firmware source commit to userland. Allows flags buffers to be passed without requiring a buffer to also be allocated as long as alloc_size is set to 0.