### PR TITLE
Fix for bug where %04d no longer works as a valid output file name

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <memory.h>
 #include <sysexits.h>
 
@@ -1089,11 +1090,21 @@ static FILE *open_filename(RASPIVID_STATE *pState, char *filename)
    {
       // Create a new filename string
 
-      // If %d or %u, assume a segment numnber, otherwise use the formatter as
-      // input to strnftime
-      if (strstr(filename,"%u") != NULL || strstr(filename,"%d") != NULL)
-      {
-          asprintf(&tempname, filename, pState->segmentNumber);
+	  //If %d/%u or any valid combination e.g. %04d is specified, assume segment number.
+	  bool bSegmentNumber = false;
+	  const char* pPercent = strstr(filename, "%");
+	  if (pPercent)
+	  {
+	  	pPercent++;
+	  	while (*pPercent != '\0' && isdigit(*pPercent))
+	  		pPercent++;
+	  	if (*pPercent == 'u' || *pPercent == 'd')
+	  		bSegmentNumber = true;
+	  }
+
+	  if (bSegmentNumber)
+	  {
+		asprintf(&tempname, filename, pState->segmentNumber);
       }
       else
       {

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1092,11 +1092,11 @@ static FILE *open_filename(RASPIVID_STATE *pState, char *filename)
 
 	  //If %d/%u or any valid combination e.g. %04d is specified, assume segment number.
 	  bool bSegmentNumber = false;
-	  const char* pPercent = strstr(filename, "%");
+	  const char* pPercent = strchr(filename, "%");
 	  if (pPercent)
 	  {
 	  	pPercent++;
-	  	while (*pPercent != '\0' && isdigit(*pPercent))
+	  	while (isdigit(*pPercent))
 	  		pPercent++;
 	  	if (*pPercent == 'u' || *pPercent == 'd')
 	  		bSegmentNumber = true;

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1092,7 +1092,7 @@ static FILE *open_filename(RASPIVID_STATE *pState, char *filename)
 
 	  //If %d/%u or any valid combination e.g. %04d is specified, assume segment number.
 	  bool bSegmentNumber = false;
-	  const char* pPercent = strchr(filename, "%");
+	  const char* pPercent = strchr(filename, '%');
 	  if (pPercent)
 	  {
 	  	pPercent++;


### PR DESCRIPTION
It appears when timestamps were added, certain combinations of output filename no longer work. Specifying %04d would take the code down the timestamp route.

I've not been able to test this code works on linux but I believe it should.

It now works with %04d and %d while preserving the new timestamp feature.

I brought up this issue here where 6by9 recommended I make a patch :)

https://www.raspberrypi.org/forums/viewtopic.php?f=43&t=224569