### PR TITLE
Raspivid: Fix for bug where %04d no longer works.

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <memory.h>
 #include <sysexits.h>
 
@@ -1089,11 +1090,21 @@ static FILE *open_filename(RASPIVID_STATE *pState, char *filename)
    {
       // Create a new filename string
 
-      // If %d or %u, assume a segment numnber, otherwise use the formatter as
-      // input to strnftime
-      if (strstr(filename,"%u") != NULL || strstr(filename,"%d") != NULL)
+      //If %d/%u or any valid combination e.g. %04d is specified, assume segment number.
+      bool bSegmentNumber = false;
+      const char* pPercent = strchr(filename, '%');
+      if (pPercent)
       {
-          asprintf(&tempname, filename, pState->segmentNumber);
+         pPercent++;
+         while (isdigit(*pPercent))
+            pPercent++;
+         if (*pPercent == 'u' || *pPercent == 'd')
+            bSegmentNumber = true;
+      }
+
+      if (bSegmentNumber)
+      {
+         asprintf(&tempname, filename, pState->segmentNumber);
       }
       else
       {


### PR DESCRIPTION
When inserting the time/date stamp into the filename was added
certain combinations of output filename no longer work. As it
was only searching for "%u" or "%d". Specifying %04d would take
the code down the timestamp route but with invalid parameters.

Make the search slightly more intelligent to allow specifying
the number of digits to insert in the filename.