### PR TITLE
aarch64: build pass

### DIFF
--- a/buildme
+++ b/buildme
@@ -27,7 +27,11 @@ elif [ "$1" = "--native" ]; then
 	# Build natively on the host
 	mkdir -p build/native/$BUILDSUBDIR
 	pushd build/native/$BUILDSUBDIR
-	cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE ../../..
+	if [ "aarch64" = `arch` ]; then
+		cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE -DARM64=ON ../../..
+	else
+		cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE ../../..
+	fi
 	shift
 	make -j `nproc` $*
 else


### PR DESCRIPTION
With `-DARM64=ON ` , build pass on arm64 arch.