### PR TITLE
userland: build pass on arm64

### DIFF
--- a/buildme
+++ b/buildme
@@ -8,11 +8,15 @@ fi
 
 BUILDSUBDIR=`echo $BUILDTYPE | tr '[A-Z]' '[a-z]'`;
 
-if [ "armv6l" = `arch` ] || [ "armv7l" = `arch` ]; then
+if [ "armv6l" = `arch` ] || [ "armv7l" = `arch` ] || [ "aarch64" = `arch` ]; then
 	# Native compile on the Raspberry Pi
 	mkdir -p build/raspberry/$BUILDSUBDIR
 	pushd build/raspberry/$BUILDSUBDIR
-	cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE ../../..
+	if [ "aarch64" = `arch` ]; then
+		cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE -DARM64=ON ../../..
+	else
+		cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE ../../..
+	fi
 	if [ "armv6l" = `arch` ]; then
 		make
 	else


### PR DESCRIPTION
With `-DARM64=ON` cmake option, build (natively) successfully on arm64 based debian (others distribution not test jet) , or fail with those error message:


```

+ mkdir -p build/raspberry/release
+ pushd build/raspberry/release
/dev/shm/userland/build/raspberry/release /dev/shm/userland
+ cmake -DCMAKE_BUILD_TYPE=Release ../../..
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Warning at makefiles/cmake/arm-linux.cmake:5 (message):
    *********************************************************
    *   CMAKE_TOOLCHAIN_FILE not defined                    *
    *   This is correct for compiling on the Raspberry Pi   *
    *                                                       *
    *   If you are cross-compiling on some other machine    *
    *   then DELETE the build directory and re-run with:    *
    *   -DCMAKE_TOOLCHAIN_FILE=toolchain_file.cmake         *
    *                                                       *
    *   Toolchain files are in makefiles/cmake/toolchains.  *
    *********************************************************
Call Stack (most recent call first):
  CMakeLists.txt:24 (include)


-- Looking for execinfo.h
-- Looking for execinfo.h - found
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29")
-- Configuring done
-- Generating done
-- Build files have been written to: /dev/shm/userland/build/raspberry/release
++ arch
+ '[' armv6l = aarch64 ']'
+ make -j4
Scanning dependencies of target vcfiled_check
Scanning dependencies of target vcos
Scanning dependencies of target EGL_static
Scanning dependencies of target khrn_client
[  0%] Building C object interface/vmcs_host/linux/vcfiled/CMakeFiles/vcfiled_check.dir/vcfiled_check.c.o
[  0%] Building C object interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_client_pointermap.c.o
[  0%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/vcos_pthreads.c.o
[  0%] Linking C static library ../../../../../../lib/libvcfiled_check.a
[  0%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/egl/egl_client_config.c.o
[  0%] Built target vcfiled_check
[  1%] Building C object interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_client_vector.c.o
Scanning dependencies of target khrn_static
[  2%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/egl/egl_client_context.c.o
[  2%] Building C object interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_int_hash.c.o
[  3%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/vcos_dlfcn.c.o
[  4%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/egl/egl_client_config.c.o
[  4%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/glibc/vcos_backtrace.c.o
[  4%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_generic_event_flags.c.o
[  4%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/egl/egl_client.c.o
[  4%] Building ASM object interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_int_hash_asm.s.o
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s: Assembler messages:
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:36: Error: unknown architecture `armv6'

/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:37: Error: unknown pseudo-op: `.object_arch'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:38: Error: unknown pseudo-op: `.arm'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:104: Warning: unknown register 'a1' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:105: Warning: unknown register 'a2' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:106: Warning: unknown register 'a3' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:107: Warning: unknown register 'a4' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:110: Warning: unknown register 'ip' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:111: Warning: unknown register 'lr' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:113: Error: operand 1 must be an integer register -- `ldr BB,=0xDEADBEEF'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:114: Error: unknown mnemonic `push' -- `push {CC,DAT0,lr}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:115: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,N,lsl#2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:116: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:117: Error: operand 1 must be an integer register -- `mov BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:118: Error: invalid use of vector register at operand 1 -- `mov CC,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:121: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#(prefetch_distance+2)*32/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:128: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#(prefetch_distance+2)*32/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:129: Error: invalid use of vector register at operand 1 -- `bic DAT0,S,#31'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:134: Error: unknown mnemonic `pld' -- `pld [DAT0,#OFFSET]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:134: Error: unknown mnemonic `pld' -- `pld [DAT0,#OFFSET]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:134: Error: unknown mnemonic `pld' -- `pld [DAT0,#OFFSET]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:135: Error: operand 1 must be an integer or stack pointer register -- `and DAT1,S,#0x1C'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:136: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT1,#0x0C'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:141: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:142: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#12/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:143: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:144: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:145: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:147: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:148: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#12/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:149: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:150: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:151: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:153: Error: operand 1 must be an integer register -- `tst S,#0x10'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:155: Error: invalid use of vector register at operand 1 -- `bic DAT0,S,#0x1F'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:156: Error: operand 1 must be an integer or stack pointer register -- `and DAT1,S,#0x1F'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:157: Error: unknown mnemonic `pld' -- `pld [DAT0,#prefetch_distance*32]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:158: Error: operand 1 must be an integer register -- `adds DAT1,N,DAT1,lsr#2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:162: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT1,#-32/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:164: Error: unknown mnemonic `pld' -- `pld [DAT0,#(prefetch_distance+1)*32]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:165: Error: operand 1 must be an integer or stack pointer register -- `add N,N,#(prefetch_distance+2)*32/4-1-3'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:166: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:167: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:168: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:169: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:171: Error: operand 1 must be an integer register -- `subs N,N,#3'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:173: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#-2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:174: Error: operand 1 must be an integer register -- `ldr DAT0,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:175: Error: unknown mnemonic `ldrhs' -- `ldrhs DAT1,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:176: Error: unknown mnemonic `ldrhi' -- `ldrhi DAT2,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:177: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:178: Error: unknown mnemonic `addhs' -- `addhs BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:179: Error: unknown mnemonic `addhi' -- `addhi CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-11'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-25'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-24'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:181: Error: operand 1 must be an integer register -- `mov a1,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:182: Error: unknown mnemonic `pop' -- `pop {CC,DAT0,pc}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:185: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:187: Error: invalid use of vector register at operand 1 -- `bic DAT0,S,#31'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:188: Error: unknown mnemonic `pld' -- `pld [DAT0]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:189: Error: operand 1 must be an integer or stack pointer register -- `add DAT1,S,N,lsl#2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:190: Error: operand 1 must be an integer or stack pointer register -- `sub DAT1,DAT1,#1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:191: Error: operand 1 must be a SIMD vector register -- `bic DAT1,DAT1,#31'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:192: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT1,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:194: Error: invalid use of vector register at operand 1 -- `add DAT0,DAT0,#32'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:195: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT0,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:196: Error: unknown mnemonic `pld' -- `pld [DAT0]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:198: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:200: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:201: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:202: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:203: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:205: Error: operand 1 must be an integer register -- `subs N,N,#3'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:207: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#-2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:208: Error: operand 1 must be an integer register -- `ldr DAT0,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:209: Error: unknown mnemonic `ldrhs' -- `ldrhs DAT1,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:210: Error: unknown mnemonic `ldrhi' -- `ldrhi DAT2,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:211: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:212: Error: unknown mnemonic `addhs' -- `addhs BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:213: Error: unknown mnemonic `addhi' -- `addhi CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-11'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-25'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-24'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:215: Error: operand 1 must be an integer register -- `mov a1,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:216: Error: unknown mnemonic `pop' -- `pop {CC,DAT0,pc}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:218: Error: unknown register alias 'S'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:219: Error: unknown register alias 'N'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:220: Error: unknown register alias 'AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:221: Error: unknown register alias 'BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:224: Error: unknown register alias 'DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:225: Error: unknown register alias 'DAT2'
interface/khronos/CMakeFiles/khrn_client.dir/build.make:134: recipe for target 'interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_int_hash_asm.s.o' failed
make[2]: *** [interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_int_hash_asm.s.o] Error 1
CMakeFiles/Makefile2:867: recipe for target 'interface/khronos/CMakeFiles/khrn_client.dir/all' failed
make[1]: *** [interface/khronos/CMakeFiles/khrn_client.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[  4%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/egl/egl_client_get_proc.c.o
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vmcs_host/vc_dispmanx.h:33,
                 from /dev/shm/userland/interface/khronos/include/EGL/eglplatform.h:110,
                 from /dev/shm/userland/interface/khronos/include/EGL/egl.h:36,
                 from /dev/shm/userland/interface/khronos/egl/egl_client_surface.h:31,
                 from /dev/shm/userland/interface/khronos/egl/egl_client.c:130:
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglInitialize’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:253:48: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_info("eglInitialize end. dpy=%d.", (int)dpy);
                                                ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:253:4: note: in expansion of macro ‘vcos_log_info’
    vcos_log_info("eglInitialize end. dpy=%d.", (int)dpy);
    ^~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglTerminate’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:313:49: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglTerminate start. dpy=%d", (int)dpy);
                                                 ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:313:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglTerminate start. dpy=%d", (int)dpy);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:338:50: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vcos_log_trace("eglTerminate end. dpy=%d", (int)dpy);
                                                  ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:338:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("eglTerminate end. dpy=%d", (int)dpy);
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglCreateWindowSurface’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:670:52: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglCreateWindowSurface end %i", (int) result);
                                                    ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:670:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglCreateWindowSurface end %i", (int) result);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglDestroySurface’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:1074:90: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglDestroySurface: surf=%d.\n calling CLIENT_LOCK_AND_GET_STATES...", (int)surf);
                                                                                          ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1074:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglDestroySurface: surf=%d.\n calling CLIENT_LOCK_AND_GET_STATES...", (int)surf);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglDestroyContext’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:1637:48: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglDestroyContext ctx=%d.", (int)ctx);
                                                ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1637:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglDestroyContext ctx=%d.", (int)ctx);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglMakeCurrent’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:53: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
                                                     ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:63: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
                                                               ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:60: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
                                                            ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:70: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
                                                                      ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglSwapBuffers’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:61: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
                                                             ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:71: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
                                                                       ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2247:54: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vcos_log_trace("eglSwapBuffers get surface %x",(int)surface);
                                                      ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2247:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("eglSwapBuffers get surface %x",(int)surface);
       ^~~~~~~~~~~~~~
[  4%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_mem_from_malloc.c.o
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglProcStateValid’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:2492:47: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglProcStateValid dpy=%d", (int)dpy );
                                               ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2492:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglProcStateValid dpy=%d", (int)dpy );
    ^~~~~~~~~~~~~~
[  4%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/egl/egl_client_context.c.o
[  4%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_generic_named_sem.c.o
[  4%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/egl/egl_client_surface.c.o
[  4%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/egl/egl_client.c.o
[  5%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_generic_safe_string.c.o
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c: In function ‘egl_surface_create’:
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:463:65: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
          sem[0] = (int)pid; sem[1] = (int)(pid >> 32); sem[2] = (int)name;
                                                                 ^
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:465:21: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
          sem_name = (int)name;
                     ^
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/khronos/common/khrn_int_util.h:37,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_rpc.h:33,
                 from /dev/shm/userland/interface/khronos/egl/egl_client_surface.c:32:
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c: In function ‘egl_surface_free’:
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:651:7: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       (uint32_t) thread, (uint32_t) surface->serverbuffer);
       ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:649:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("egl_surface_free: calling eglIntDestroySurface_impl via RPC...; "
    ^~~~~~~~~~~~~~
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vmcs_host/vc_dispmanx.h:33,
                 from /dev/shm/userland/interface/khronos/include/EGL/eglplatform.h:110,
                 from /dev/shm/userland/interface/khronos/include/EGL/egl.h:36,
                 from /dev/shm/userland/interface/khronos/egl/egl_client_surface.h:31,
                 from /dev/shm/userland/interface/khronos/egl/egl_client.c:130:
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglInitialize’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:253:48: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_info("eglInitialize end. dpy=%d.", (int)dpy);
                                                ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:253:4: note: in expansion of macro ‘vcos_log_info’
    vcos_log_info("eglInitialize end. dpy=%d.", (int)dpy);
    ^~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglTerminate’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:313:49: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglTerminate start. dpy=%d", (int)dpy);
                                                 ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:313:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglTerminate start. dpy=%d", (int)dpy);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:338:50: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vcos_log_trace("eglTerminate end. dpy=%d", (int)dpy);
                                                  ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:338:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("eglTerminate end. dpy=%d", (int)dpy);
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglCreateWindowSurface’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:670:52: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglCreateWindowSurface end %i", (int) result);
                                                    ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:670:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglCreateWindowSurface end %i", (int) result);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglDestroySurface’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:1074:90: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglDestroySurface: surf=%d.\n calling CLIENT_LOCK_AND_GET_STATES...", (int)surf);
                                                                                          ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1074:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglDestroySurface: surf=%d.\n calling CLIENT_LOCK_AND_GET_STATES...", (int)surf);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglDestroyContext’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:1637:48: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglDestroyContext ctx=%d.", (int)ctx);
                                                ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1637:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglDestroyContext ctx=%d.", (int)ctx);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglMakeCurrent’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:53: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
                                                     ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:63: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
                                                               ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:1963:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent %d %d %x", (int)ctx, (int)dr, (unsigned int) thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:60: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
                                                            ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:70: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
                                                                      ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2047:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("Actual eglMakeCurrent end %d %d %d %x", (int)ctx, (int)dr, result, (unsigned int)thread->error);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglSwapBuffers’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:61: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
                                                             ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:71: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
                                                                       ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2237:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglSwapBuffers start. dpy=%d. surf=%d.", (int)dpy, (int)surf);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2247:54: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vcos_log_trace("eglSwapBuffers get surface %x",(int)surface);
                                                      ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2247:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("eglSwapBuffers get surface %x",(int)surface);
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/egl/egl_client.c: In function ‘eglProcStateValid’:
/dev/shm/userland/interface/khronos/egl/egl_client.c:2492:47: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglProcStateValid dpy=%d", (int)dpy );
                                               ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client.c:2492:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglProcStateValid dpy=%d", (int)dpy );
    ^~~~~~~~~~~~~~
[  5%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_generic_reentrant_mtx.c.o
[  5%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_brcm_driver_monitor_client.c.o
[  5%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_abort.c.o
[  6%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_brcm_perf_monitor_client.c.o
[  6%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_cmd.c.o
[  6%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/egl/egl_client_get_proc.c.o
[  6%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_brcm_global_image_client.c.o
[  6%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_brcm_flush_client.c.o
[  6%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_khr_image_client.c.o
[  7%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_khr_sync_client.c.o
[  8%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_init.c.o
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c: In function ‘egl_sync_create’:
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c:89:24: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    sync_ptr->name[2] = (int)sync;
                        ^
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c:96:10: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    sem = (uint32_t) sync;
          ^
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c: In function ‘egl_sync_destroy_iterator’:
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c:146:27: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
    EGL_SYNC_T *sync_ptr = (EGL_SYNC_T *) sync;
                           ^
[  9%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/egl/egl_client_surface.c.o
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c: In function ‘eglCreateImageKHR’:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:186:34: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                         buf[0] = (uint32_t)image.aux;
                                  ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:208:25: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                buf[0] = (uint32_t)wrap_buffer->storage;
                         ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:342:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:346:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:350:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:354:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:360:25: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                buf[0] = (uint32_t)buffer;
                         ^
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vmcs_host/vc_dispmanx.h:33,
                 from /dev/shm/userland/interface/khronos/include/EGL/eglplatform.h:110,
                 from /dev/shm/userland/interface/khronos/include/EGL/egl.h:36,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_platform.h:30,
                 from /dev/shm/userland/interface/khronos/common/khrn_client.h:34,
                 from /dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:35:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c: In function ‘eglDestroyImageKHR’:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:458:53: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglDestroyImageKHR image=%d.\n", (int)image);
                                                     ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:458:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglDestroyImageKHR image=%d.\n", (int)image);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c: In function ‘eglIntImageSetColorData’:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:512:67: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vcos_log_trace("[%s] egl im %d (%d,%d,%d,%d)",__FUNCTION__, (uint32_t)image, x_offset, y_offset, width, height);
                                                                   ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:512:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("[%s] egl im %d (%d,%d,%d,%d)",__FUNCTION__, (uint32_t)image, x_offset, y_offset, width, height);
       ^~~~~~~~~~~~~~
In file included from /dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:36:0:
/dev/shm/userland/interface/khronos/common/khrn_client_rpc.h:430:30: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
 #define RPC_UINT(u)         ((uint32_t)(u))
                              ^
/dev/shm/userland/interface/khronos/common/khrn_client_rpc.h:757:119: note: in definition of macro ‘RPC_CALL8_IN_BULK’
 #define RPC_CALL8_IN_BULK(fn, thread, id, p0, p1, p2, p3, p4, p5, p6, in, len)          rpc_call8_in_bulk(thread, id, p0, p1, p2, p3, p4, p5, p6, in, len)
                                                                                                                       ^~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:520:16: note: in expansion of macro ‘RPC_UINT’
                RPC_UINT(image), format, x_offset, y, width, n, stride,
                ^~~~~~~~
[  9%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_msgqueue.c.o
[  9%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_logcat.c.o
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c: In function ‘egl_surface_create’:
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:463:65: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
          sem[0] = (int)pid; sem[1] = (int)(pid >> 32); sem[2] = (int)name;
                                                                 ^
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:465:21: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
          sem_name = (int)name;
                     ^
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/khronos/common/khrn_int_util.h:37,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_rpc.h:33,
                 from /dev/shm/userland/interface/khronos/egl/egl_client_surface.c:32:
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c: In function ‘egl_surface_free’:
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:651:7: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       (uint32_t) thread, (uint32_t) surface->serverbuffer);
       ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/egl/egl_client_surface.c:649:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("egl_surface_free: calling eglIntDestroySurface_impl via RPC...; "
    ^~~~~~~~~~~~~~
[  9%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/gl_oes_egl_image_client.c.o
[  9%] Building C object interface/vcos/pthreads/CMakeFiles/vcos.dir/__/generic/vcos_generic_blockpool.c.o
[  9%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_khr_lock_surface_client.c.o
[  9%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_brcm_driver_monitor_client.c.o
[  9%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_brcm_perf_monitor_client.c.o
[  9%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_brcm_global_image_client.c.o
[  9%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_brcm_flush_client.c.o
[  9%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/ext_gl_debug_marker.c.o
[  9%] Linking C shared library ../../../../../lib/libvcos.so
[  9%] Built target vcos
[ 10%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_khr_image_client.c.o
[ 10%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_khr_sync_client.c.o
[ 10%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/gl_oes_egl_image_client.c.o
[ 10%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/common/khrn_int_image.c.o
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c: In function ‘eglCreateImageKHR’:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:186:34: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                         buf[0] = (uint32_t)image.aux;
                                  ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:208:25: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                buf[0] = (uint32_t)wrap_buffer->storage;
                         ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:342:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:346:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:350:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:354:28: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   buf[0] = (uint32_t)buffer;
                            ^
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:360:25: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                buf[0] = (uint32_t)buffer;
                         ^
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vmcs_host/vc_dispmanx.h:33,
                 from /dev/shm/userland/interface/khronos/include/EGL/eglplatform.h:110,
                 from /dev/shm/userland/interface/khronos/include/EGL/egl.h:36,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_platform.h:30,
                 from /dev/shm/userland/interface/khronos/common/khrn_client.h:34,
                 from /dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:35:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c: In function ‘eglDestroyImageKHR’:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:458:53: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("eglDestroyImageKHR image=%d.\n", (int)image);
                                                     ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:458:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("eglDestroyImageKHR image=%d.\n", (int)image);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c: In function ‘eglIntImageSetColorData’:
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:512:67: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vcos_log_trace("[%s] egl im %d (%d,%d,%d,%d)",__FUNCTION__, (uint32_t)image, x_offset, y_offset, width, height);
                                                                   ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:512:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("[%s] egl im %d (%d,%d,%d,%d)",__FUNCTION__, (uint32_t)image, x_offset, y_offset, width, height);
       ^~~~~~~~~~~~~~
In file included from /dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:36:0:
/dev/shm/userland/interface/khronos/common/khrn_client_rpc.h:430:30: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
 #define RPC_UINT(u)         ((uint32_t)(u))
                              ^
/dev/shm/userland/interface/khronos/common/khrn_client_rpc.h:757:119: note: in definition of macro ‘RPC_CALL8_IN_BULK’
 #define RPC_CALL8_IN_BULK(fn, thread, id, p0, p1, p2, p3, p4, p5, p6, in, len)          rpc_call8_in_bulk(thread, id, p0, p1, p2, p3, p4, p5, p6, in, len)
                                                                                                                       ^~
/dev/shm/userland/interface/khronos/ext/egl_khr_image_client.c:520:16: note: in expansion of macro ‘RPC_UINT’
                RPC_UINT(image), format, x_offset, y, width, n, stride,
                ^~~~~~~~
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c: In function ‘egl_sync_create’:
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c:89:24: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    sync_ptr->name[2] = (int)sync;
                        ^
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c:96:10: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    sem = (uint32_t) sync;
          ^
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c: In function ‘egl_sync_destroy_iterator’:
/dev/shm/userland/interface/khronos/ext/egl_khr_sync_client.c:146:27: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
    EGL_SYNC_T *sync_ptr = (EGL_SYNC_T *) sync;
                           ^
[ 11%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/common/khrn_int_util.c.o
[ 11%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_khr_lock_surface_client.c.o
[ 12%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/ext_gl_debug_marker.c.o
[ 12%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/common/khrn_options.c.o
In file included from /dev/shm/userland/interface/khronos/common/khrn_int_util.c:30:0:
/dev/shm/userland/interface/khronos/common/khrn_int_util.c: In function ‘khrn_clip_range2’:
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:145:57: warning: assuming signed overflow does not occur when assuming that (X - c) <= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z < x) ? (int32_t)0x7fffffff : z) : ((z > x) ? (int32_t)0x80000000 : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:151:57: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z > x) ? (int32_t)0x80000000 : z) : ((z < x) ? (int32_t)0x7fffffff : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:145:57: warning: assuming signed overflow does not occur when assuming that (X - c) <= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z < x) ? (int32_t)0x7fffffff : z) : ((z > x) ? (int32_t)0x80000000 : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:151:57: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z > x) ? (int32_t)0x80000000 : z) : ((z < x) ? (int32_t)0x7fffffff : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 12%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/common/khrn_client_global_image_map.c.o
[ 12%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/common/khrn_int_image.c.o
[ 12%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/common/khrn_int_util.c.o
[ 12%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/common/khrn_options.c.o
In file included from /dev/shm/userland/interface/khronos/common/khrn_int_util.c:30:0:
/dev/shm/userland/interface/khronos/common/khrn_int_util.c: In function ‘khrn_clip_range2’:
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:145:57: warning: assuming signed overflow does not occur when assuming that (X - c) <= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z < x) ? (int32_t)0x7fffffff : z) : ((z > x) ? (int32_t)0x80000000 : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:151:57: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z > x) ? (int32_t)0x80000000 : z) : ((z < x) ? (int32_t)0x7fffffff : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:145:57: warning: assuming signed overflow does not occur when assuming that (X - c) <= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z < x) ? (int32_t)0x7fffffff : z) : ((z > x) ? (int32_t)0x80000000 : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_int_util.h:151:57: warning: assuming signed overflow does not occur when assuming that (X + c) >= X is always true [-Wstrict-overflow]
    return (y > 0) ? ((z > x) ? (int32_t)0x80000000 : z) : ((z < x) ? (int32_t)0x7fffffff : z);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 12%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/common/khrn_client_global_image_map.c.o
[ 12%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/common/linux/khrn_client_rpc_linux.c.o
[ 13%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/common/linux/khrn_client_platform_linux.c.o
[ 13%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/vg/vg_int_mat3x3.c.o
[ 14%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/common/linux/khrn_client_rpc_linux.c.o
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vmcs_host/vc_dispmanx.h:33,
                 from /dev/shm/userland/interface/khronos/include/EGL/eglplatform.h:110,
                 from /dev/shm/userland/interface/khronos/include/EGL/egl.h:36,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_platform.h:30,
                 from /dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:29:
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c: In function ‘send_bound_pixmap’:
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:666:49: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("send_bound_pixmap %d %d", i, (int)pixmap_binding[i].egl_image);
                                                 ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:666:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("send_bound_pixmap %d %d", i, (int)pixmap_binding[i].egl_image);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c: In function ‘check_default’:
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:731:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    int wid = (int)win;
              ^
[ 14%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/vg/vg_client.c.o
[ 14%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/common/khrn_client.c.o
[ 14%] Building C object interface/khronos/CMakeFiles/EGL_static.dir/ext/egl_openmaxil_client.c.o
In file included from /dev/shm/userland/interface/khronos/common/khrn_int_common.h:137:0,
                 from /dev/shm/userland/interface/khronos/common/khrn_client.c:28:
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:44:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLConfig) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:45:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLContext) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:46:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLDisplay) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:47:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLSurface) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:48:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLClientBuffer) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:49:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(NativeDisplayType) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:50:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(NativePixmapType) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:51:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(NativeWindowType) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:71:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(GLintptr) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:72:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(GLsizeiptr) == 4);
 ^~~~~~~~~~~~~~~~~~
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/khronos/common/khrn_int_util.h:37,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:31,
                 from /dev/shm/userland/interface/khronos/common/khrn_client.c:30:
/dev/shm/userland/interface/khronos/common/khrn_client.c: In function ‘client_send_make_current’:
/dev/shm/userland/interface/khronos/common/khrn_client.c:392:18: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                  (unsigned int)(char *)thread->opengl.context, (unsigned int)(char *)thread->opengl.draw);
                  ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:391:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send null make current %x %x",
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:392:64: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                  (unsigned int)(char *)thread->opengl.context, (unsigned int)(char *)thread->opengl.draw);
                                                                ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:391:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send null make current %x %x",
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:397:13: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
             (int)thread->opengl.context->name,
             ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:396:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send make current %d[%d %s%s] %d[%d %d%s]",
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:401:13: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
             (int)thread->opengl.draw->name,
             ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:396:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send make current %d[%d %s%s] %d[%d %d%s]",
       ^~~~~~~~~~~~~~
interface/khronos/CMakeFiles/EGL_static.dir/build.make:590: recipe for target 'interface/khronos/CMakeFiles/EGL_static.dir/common/khrn_client.c.o' failed
make[2]: *** [interface/khronos/CMakeFiles/EGL_static.dir/common/khrn_client.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 14%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/common/linux/khrn_client_platform_linux.c.o
[ 14%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/vg/vg_int_mat3x3.c.o
[ 14%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/vg/vg_client.c.o
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vmcs_host/vc_dispmanx.h:33,
                 from /dev/shm/userland/interface/khronos/include/EGL/eglplatform.h:110,
                 from /dev/shm/userland/interface/khronos/include/EGL/egl.h:36,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_platform.h:30,
                 from /dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:29:
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c: In function ‘send_bound_pixmap’:
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:666:49: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace("send_bound_pixmap %d %d", i, (int)pixmap_binding[i].egl_image);
                                                 ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:666:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace("send_bound_pixmap %d %d", i, (int)pixmap_binding[i].egl_image);
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c: In function ‘check_default’:
/dev/shm/userland/interface/khronos/common/linux/khrn_client_platform_linux.c:731:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    int wid = (int)win;
              ^
[ 15%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/common/khrn_client.c.o
[ 15%] Building C object interface/khronos/CMakeFiles/khrn_static.dir/ext/egl_openmaxil_client.c.o
In file included from /dev/shm/userland/interface/khronos/common/khrn_int_common.h:137:0,
                 from /dev/shm/userland/interface/khronos/common/khrn_client.c:28:
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:44:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLConfig) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:45:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLContext) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:46:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLDisplay) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:47:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLSurface) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:48:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(EGLClientBuffer) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:49:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(NativeDisplayType) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:50:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(NativePixmapType) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:51:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(NativeWindowType) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:71:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(GLintptr) == 4);
 ^~~~~~~~~~~~~~~~~~
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:303:69: error: size of array ‘vcos_static_assert’ is negative
 #define vcos_static_assert(cond) __attribute__((unused)) extern int vcos_static_assert[(cond)?1:-1]
                                                                     ^
/dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:72:1: note: in expansion of macro ‘vcos_static_assert’
 vcos_static_assert(sizeof(GLsizeiptr) == 4);
 ^~~~~~~~~~~~~~~~~~
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/khronos/common/khrn_int_util.h:37,
                 from /dev/shm/userland/interface/khronos/common/khrn_client_check_types.h:31,
                 from /dev/shm/userland/interface/khronos/common/khrn_client.c:30:
/dev/shm/userland/interface/khronos/common/khrn_client.c: In function ‘client_send_make_current’:
/dev/shm/userland/interface/khronos/common/khrn_client.c:392:18: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                  (unsigned int)(char *)thread->opengl.context, (unsigned int)(char *)thread->opengl.draw);
                  ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:391:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send null make current %x %x",
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:392:64: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                  (unsigned int)(char *)thread->opengl.context, (unsigned int)(char *)thread->opengl.draw);
                                                                ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:391:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send null make current %x %x",
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:397:13: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
             (int)thread->opengl.context->name,
             ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:396:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send make current %d[%d %s%s] %d[%d %d%s]",
       ^~~~~~~~~~~~~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:401:13: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
             (int)thread->opengl.draw->name,
             ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/khronos/common/khrn_client.c:396:7: note: in expansion of macro ‘vcos_log_trace’
       vcos_log_trace("Send make current %d[%d %s%s] %d[%d %d%s]",
       ^~~~~~~~~~~~~~
interface/khronos/CMakeFiles/khrn_static.dir/build.make:590: recipe for target 'interface/khronos/CMakeFiles/khrn_static.dir/common/khrn_client.c.o' failed
make[2]: *** [interface/khronos/CMakeFiles/khrn_static.dir/common/khrn_client.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:787: recipe for target 'interface/khronos/CMakeFiles/khrn_static.dir/all' failed
make[1]: *** [interface/khronos/CMakeFiles/khrn_static.dir/all] Error 2
CMakeFiles/Makefile2:622: recipe for target 'interface/khronos/CMakeFiles/EGL_static.dir/all' failed
make[1]: *** [interface/khronos/CMakeFiles/EGL_static.dir/all] Error 2
Makefile:149: recipe for target 'all' failed
make: *** [all] Error 2
+ '[' '' '!=' '' ']'
+ sudo make install
[  3%] Built target vcos
Scanning dependencies of target vchiq_arm
[  3%] Building C object interface/vchiq_arm/CMakeFiles/vchiq_arm.dir/vchiq_lib.c.o
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vchi/vchi_mh.h:31,
                 from /dev/shm/userland/interface/vchiq_arm/vchiq_if.h:31,
                 from /dev/shm/userland/interface/vchiq_arm/vchiq.h:31,
                 from /dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:33:
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c: In function ‘vchiq_release_message’:
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:401:77: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    vcos_log_trace( "%s handle=%08x, header=%x", __func__, (uint32_t)handle, (uint32_t)header );
                                                                             ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:401:4: note: in expansion of macro ‘vcos_log_trace’
    vcos_log_trace( "%s handle=%08x, header=%x", __func__, (uint32_t)handle, (uint32_t)header );
    ^~~~~~~~~~~~~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c: In function ‘vchiq_dump_phys_mem’:
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1399:31: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
    VCHIQ_SERVICE_T *service = (VCHIQ_SERVICE_T *)handle;
                               ^
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vchi/vchi_mh.h:31,
                 from /dev/shm/userland/interface/vchiq_arm/vchiq_if.h:31,
                 from /dev/shm/userland/interface/vchiq_arm/vchiq.h:31,
                 from /dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:33:
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c: In function ‘completion_thread’:
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1552:36: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                completion->reason, (uint32_t)completion->header,
                                    ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1551:13: note: in expansion of macro ‘vcos_log_trace’
             vcos_log_trace( "callback(%x, %x, %x(%x,%x), %x)",
             ^~~~~~~~~~~~~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1553:16: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                (uint32_t)&service->base, (uint32_t)service->lib_handle, (uint32_t)service->base.userdata, (uint32_t)completion->bulk_userdata );
                ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1551:13: note: in expansion of macro ‘vcos_log_trace’
             vcos_log_trace( "callback(%x, %x, %x(%x,%x), %x)",
             ^~~~~~~~~~~~~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1553:73: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                (uint32_t)&service->base, (uint32_t)service->lib_handle, (uint32_t)service->base.userdata, (uint32_t)completion->bulk_userdata );
                                                                         ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1551:13: note: in expansion of macro ‘vcos_log_trace’
             vcos_log_trace( "callback(%x, %x, %x(%x,%x), %x)",
             ^~~~~~~~~~~~~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1553:107: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                (uint32_t)&service->base, (uint32_t)service->lib_handle, (uint32_t)service->base.userdata, (uint32_t)completion->bulk_userdata );
                                                                                                           ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/vchiq_arm/vchiq_lib.c:1551:13: note: in expansion of macro ‘vcos_log_trace’
             vcos_log_trace( "callback(%x, %x, %x(%x,%x), %x)",
             ^~~~~~~~~~~~~~
[  4%] Building C object interface/vchiq_arm/CMakeFiles/vchiq_arm.dir/vchiq_util.c.o
[  4%] Linking C shared library ../../../../lib/libvchiq_arm.so
[  4%] Built target vchiq_arm
[  4%] Built target vcfiled_check
Scanning dependencies of target vchostif
[  5%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/linux/vcfilesys.c.o
[  5%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/linux/vcmisc.c.o
[  5%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/vc_vchi_gencmd.c.o
[  5%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/vc_vchi_filesys.c.o
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c: In function ‘vc_filesys_mount’:
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:517:29: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       len = a + b + c + 3 + (int)(((FILESERV_MSG_T *)0)->data);
                             ^
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c: In function ‘vc_filesys_closedir’:
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:912:35: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
    return vc_filesys_single_param((uint32_t)dhandle, VC_FILESYS_CLOSEDIR);
                                   ^
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c: In function ‘vc_filesys_opendir’:
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:1111:11: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
    return (void *) vc_filesys_single_string(0, dirname, VC_FILESYS_OPENDIR, 1);
           ^
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c: In function ‘vc_filesys_readdir_r’:
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:1182:50: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vc_filesys_client.fileserv_msg.params[0] = (uint32_t)dhandle;
                                                  ^
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c: In function ‘vc_fs_message_handler’:
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:1909:33: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
          i = vc_hostfs_closedir((void *)msg->params[0]);
                                 ^
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:2021:27: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
          msg->params[0] = (uint32_t)vc_hostfs_opendir(
                           ^
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:2023:14: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
          if ((void *)msg->params[0] == NULL) {
              ^
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:114:0,
                 from /dev/shm/userland/interface/vmcs_host/linux/vchost_config.h:31,
                 from /dev/shm/userland/interface/vmcs_host/vchost_platform_config.h:29,
                 from /dev/shm/userland/interface/vmcs_host/vchost.h:31,
                 from /dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:33:
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:2038:30: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
             if(!vcos_verify(((int)vc_filesys_client.bulk_buffer & (VCHI_BULK_ALIGN-1)) == 0 &&
                              ^
/dev/shm/userland/build/inc/interface/vcos/vcos_assert.h:291:28: note: in definition of macro ‘vcos_verify’
 #define vcos_verify(cond) (cond)
                            ^~~~
/dev/shm/userland/interface/vmcs_host/vc_vchi_filesys.c:2165:37: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
             if (vc_hostfs_readdir_r((void *)msg->params[0],
                                     ^
[  5%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/vc_vchi_gpuserv.c.o
[  6%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/vc_vchi_tvservice.c.o
[  6%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/vc_vchi_cecservice.c.o
In file included from /dev/shm/userland/build/inc/interface/vcos/vcos.h:144:0,
                 from /dev/shm/userland/interface/vmcs_host/linux/vchost_config.h:31,
                 from /dev/shm/userland/interface/vmcs_host/vchost_platform_config.h:29,
                 from /dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c:29:
/dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c: In function ‘vc_cec_register_callback’:
/dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c:359:63: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vc_cec_log_info("CEC service registered callback 0x%x", (uint32_t) callback);
                                                               ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c:359:7: note: in expansion of macro ‘vc_cec_log_info’
       vc_cec_log_info("CEC service registered callback 0x%x", (uint32_t) callback);
       ^~~~~~~~~~~~~~~
/dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c:362:71: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       vc_cec_log_error("CEC service registered callback 0x%x failed", (uint32_t) callback);
                                                                       ^
/dev/shm/userland/build/inc/interface/vcos/vcos_logging.h:234:113: note: in definition of macro ‘_VCOS_LOG_X’
 #  define _VCOS_LOG_X(cat, _level, fmt...)   do { if (vcos_is_log_enabled(cat,_level)) vcos_log_impl(cat,_level,fmt); } while (0)
                                                                                                                 ^~~
/dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c:362:7: note: in expansion of macro ‘vc_cec_log_error’
       vc_cec_log_error("CEC service registered callback 0x%x failed", (uint32_t) callback);
       ^~~~~~~~~~~~~~~~
At top level:
/dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c:138:23: warning: ‘max_devicetype_strings’ defined but not used [-Wunused-const-variable=]
 static const uint32_t max_devicetype_strings = sizeof(cecservice_devicetype_strings)/sizeof(char *);
                       ^~~~~~~~~~~~~~~~~~~~~~
/dev/shm/userland/interface/vmcs_host/vc_vchi_cecservice.c:106:23: warning: ‘max_command_strings’ defined but not used [-Wunused-const-variable=]
 static const uint32_t max_command_strings = sizeof(cecservice_command_strings)/sizeof(char *);
                       ^~~~~~~~~~~~~~~~~~~
[  6%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/vc_vchi_dispmanx.c.o
[  6%] Building C object interface/vmcs_host/CMakeFiles/vchostif.dir/vc_service_common.c.o
/dev/shm/userland/interface/vmcs_host/vc_service_common.c: In function ‘vchi2service_status_string’:
/dev/shm/userland/interface/vmcs_host/vc_service_common.c:51:4: warning: case value ‘1’ not in enumerated type ‘VC_SERVICE_VCHI_STATUS_T {aka enum <anonymous>}’ [-Wswitch]
    case VCHIQ_RETRY:
    ^~~~
[  7%] Linking C static library ../../../../lib/libvchostif.a
[  7%] Built target vchostif
Scanning dependencies of target bcm_host
[  7%] Building C object host_applications/linux/libs/bcm_host/CMakeFiles/bcm_host.dir/bcm_host.c.o
[  7%] Building C object host_applications/linux/libs/bcm_host/CMakeFiles/bcm_host.dir/__/__/__/__/interface/vmcs_host/linux/vcfilesys.c.o
[  7%] Building C object host_applications/linux/libs/bcm_host/CMakeFiles/bcm_host.dir/__/__/__/__/interface/vmcs_host/linux/vcfiled/vcfiled_check.c.o
[  8%] Linking C shared library ../../../../../../lib/libbcm_host.so
[  8%] Built target bcm_host
[  8%] Building ASM object interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_int_hash_asm.s.o
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s: Assembler messages:
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:36: Error: unknown architecture `armv6'

/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:37: Error: unknown pseudo-op: `.object_arch'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:38: Error: unknown pseudo-op: `.arm'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:104: Warning: unknown register 'a1' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:105: Warning: unknown register 'a2' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:106: Warning: unknown register 'a3' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:107: Warning: unknown register 'a4' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:110: Warning: unknown register 'ip' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:111: Warning: unknown register 'lr' -- .req ignored
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:113: Error: operand 1 must be an integer register -- `ldr BB,=0xDEADBEEF'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:114: Error: unknown mnemonic `push' -- `push {CC,DAT0,lr}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:115: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,N,lsl#2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:116: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:117: Error: operand 1 must be an integer register -- `mov BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:118: Error: invalid use of vector register at operand 1 -- `mov CC,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:121: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#(prefetch_distance+2)*32/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:128: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#(prefetch_distance+2)*32/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:129: Error: invalid use of vector register at operand 1 -- `bic DAT0,S,#31'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:134: Error: unknown mnemonic `pld' -- `pld [DAT0,#OFFSET]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:134: Error: unknown mnemonic `pld' -- `pld [DAT0,#OFFSET]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:134: Error: unknown mnemonic `pld' -- `pld [DAT0,#OFFSET]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:135: Error: operand 1 must be an integer or stack pointer register -- `and DAT1,S,#0x1C'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:136: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT1,#0x0C'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:141: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:142: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#12/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:143: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:144: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:145: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:146: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:147: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:148: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#12/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:149: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:150: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:151: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:152: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:153: Error: operand 1 must be an integer register -- `tst S,#0x10'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:155: Error: invalid use of vector register at operand 1 -- `bic DAT0,S,#0x1F'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:156: Error: operand 1 must be an integer or stack pointer register -- `and DAT1,S,#0x1F'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:157: Error: unknown mnemonic `pld' -- `pld [DAT0,#prefetch_distance*32]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:158: Error: operand 1 must be an integer register -- `adds DAT1,N,DAT1,lsr#2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:162: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT1,#-32/4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:164: Error: unknown mnemonic `pld' -- `pld [DAT0,#(prefetch_distance+1)*32]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:165: Error: operand 1 must be an integer or stack pointer register -- `add N,N,#(prefetch_distance+2)*32/4-1-3'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:166: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:167: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:168: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:169: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:170: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:171: Error: operand 1 must be an integer register -- `subs N,N,#3'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:173: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#-2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:174: Error: operand 1 must be an integer register -- `ldr DAT0,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:175: Error: unknown mnemonic `ldrhs' -- `ldrhs DAT1,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:176: Error: unknown mnemonic `ldrhi' -- `ldrhi DAT2,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:177: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:178: Error: unknown mnemonic `addhs' -- `addhs BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:179: Error: unknown mnemonic `addhi' -- `addhi CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-11'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-25'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:180: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-24'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:181: Error: operand 1 must be an integer register -- `mov a1,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:182: Error: unknown mnemonic `pop' -- `pop {CC,DAT0,pc}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:185: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:187: Error: invalid use of vector register at operand 1 -- `bic DAT0,S,#31'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:188: Error: unknown mnemonic `pld' -- `pld [DAT0]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:189: Error: operand 1 must be an integer or stack pointer register -- `add DAT1,S,N,lsl#2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:190: Error: operand 1 must be an integer or stack pointer register -- `sub DAT1,DAT1,#1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:191: Error: operand 1 must be a SIMD vector register -- `bic DAT1,DAT1,#31'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:192: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT1,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:194: Error: invalid use of vector register at operand 1 -- `add DAT0,DAT0,#32'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:195: Error: operand 1 must be an integer or stack pointer register -- `cmp DAT0,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:196: Error: unknown mnemonic `pld' -- `pld [DAT0]'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:198: Error: operand 1 must be an integer or stack pointer register -- `sub N,N,#1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:200: Error: unknown mnemonic `ldmia' -- `ldmia S!,{DAT0,DAT1,DAT2}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:201: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:202: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:203: Error: invalid use of vector register at operand 1 -- `add CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-6'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-8'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `add CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA,ror#32-19'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:204: Error: operand 1 must be an integer or stack pointer register -- `add BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:205: Error: operand 1 must be an integer register -- `subs N,N,#3'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:207: Error: operand 1 must be an integer or stack pointer register -- `cmp N,#-2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:208: Error: operand 1 must be an integer register -- `ldr DAT0,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:209: Error: unknown mnemonic `ldrhs' -- `ldrhs DAT1,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:210: Error: unknown mnemonic `ldrhi' -- `ldrhi DAT2,[S],#4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:211: Error: operand 1 must be an integer or stack pointer register -- `add AA,AA,DAT0'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:212: Error: unknown mnemonic `addhs' -- `addhs BB,BB,DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:213: Error: unknown mnemonic `addhi' -- `addhi CC,CC,DAT2'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-11'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-25'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-16'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor AA,AA,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub AA,AA,CC,ror#32-4'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `eor BB,BB,AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: operand 1 must be an integer or stack pointer register -- `sub BB,BB,AA,ror#32-14'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `eor CC,CC,BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:214: Error: invalid use of vector register at operand 1 -- `sub CC,CC,BB,ror#32-24'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:215: Error: operand 1 must be an integer register -- `mov a1,CC'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:216: Error: unknown mnemonic `pop' -- `pop {CC,DAT0,pc}'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:218: Error: unknown register alias 'S'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:219: Error: unknown register alias 'N'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:220: Error: unknown register alias 'AA'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:221: Error: unknown register alias 'BB'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:224: Error: unknown register alias 'DAT1'
/dev/shm/userland/interface/khronos/common/khrn_int_hash_asm.s:225: Error: unknown register alias 'DAT2'
interface/khronos/CMakeFiles/khrn_client.dir/build.make:134: recipe for target 'interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_int_hash_asm.s.o' failed
make[2]: *** [interface/khronos/CMakeFiles/khrn_client.dir/common/khrn_int_hash_asm.s.o] Error 1
CMakeFiles/Makefile2:867: recipe for target 'interface/khronos/CMakeFiles/khrn_client.dir/all' failed
make[1]: *** [interface/khronos/CMakeFiles/khrn_client.dir/all] Error 2
Makefile:149: recipe for target 'all' failed
make: *** [all] Error 2

```