### PR TITLE
Fixed #1077: hello_triangle2, 'vertex' attribute for Mandelbrot

### DIFF
--- a/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
+++ b/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
@@ -382,6 +382,9 @@ static void init_shaders(CUBE_STATE_T *state)
                              vertex_data, GL_STATIC_DRAW);
         glVertexAttribPointer(state->attr_vertex, 4, GL_FLOAT, 0, 16, 0);
         glEnableVertexAttribArray(state->attr_vertex);
+        glVertexAttribPointer(state->attr_vertex2, 4, GL_FLOAT, 0, 16, 0);
+        glEnableVertexAttribArray(state->attr_vertex2);
+
         check();
 }
 


### PR DESCRIPTION
Fixed #1077: hello_triangle2, vertex attribute for Mandelbrot program is not linked