### PR TITLE
CamApps : Removed version number and replace with commit id

### DIFF
--- a/host_applications/linux/apps/raspicam/CMakeLists.txt
+++ b/host_applications/linux/apps/raspicam/CMakeLists.txt
@@ -12,6 +12,23 @@ include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/bcm_host/
 include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/apps/raspicam/)
 include_directories(${PROJECT_SOURCE_DIR}/host_applications/linux/libs/sm)
 
+# Find the commit hash of the build and pass to the compiler
+execute_process(
+  COMMAND git log -1 --abbrev=12 --format=%h
+  OUTPUT_VARIABLE GIT_COMMIT_ID
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+add_definitions("-DGIT_COMMIT_ID=\"${GIT_COMMIT_ID}\"")
+
+# Determine if we are tainted
+execute_process(
+  COMMAND bash "-c" "git ls-files -m | wc -l"
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_TAINTED
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+add_definitions("-DGIT_TAINTED=${GIT_TAINTED}")
+
 set (GL_SCENE_SOURCES
    gl_scenes/models.c
    gl_scenes/mirror.c

--- a/host_applications/linux/apps/raspicam/RaspiHelpers.c
+++ b/host_applications/linux/apps/raspicam/RaspiHelpers.c
@@ -46,11 +46,29 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RaspiCamControl.h"
 #include "RaspiCommonSettings.h"
 
+#ifndef GIT_COMMIT_ID
+#define GIT_COMMIT_ID "Not found"
+#endif
+
+#if (GIT_TAINTED > 0)
+#define TAINTED " Tainted"
+#else
+#define TAINTED ""
+#endif
+
 static const char *app_name;
+
+void print_app_details(FILE *fd)
+{
+   if (!app_name)
+      app_name = "Un-named";
+
+   fprintf(fd, "\n\"%s\" Camera App (commit %s%s)\n\n", basename(app_name), GIT_COMMIT_ID, TAINTED);
+}
 
 void display_valid_parameters(char *name, void (*app_help)(char*))
 {
-   fprintf(stdout, "\n%s Camera App\n\n", basename(app_name));
+   print_app_details(stdout);
 
    // This should be defined in the main app source code
    if (app_help)

--- a/host_applications/linux/apps/raspicam/RaspiHelpers.h
+++ b/host_applications/linux/apps/raspicam/RaspiHelpers.h
@@ -37,6 +37,6 @@ MMAL_STATUS_T connect_ports(MMAL_PORT_T *output_port, MMAL_PORT_T *input_port, M
 void check_disable_port(MMAL_PORT_T *port);
 void default_signal_handler(int signal_number);
 int mmal_status_to_int(MMAL_STATUS_T status);
-
+void print_app_details(FILE *fd);
 
 #endif

--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -58,8 +58,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <errno.h>
 #include <sysexits.h>
 
-#define VERSION_STRING "v1.3.11"
-
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"
 
@@ -1760,8 +1758,7 @@ int main(int argc, const char **argv)
 
    if (state.common_settings.verbose)
    {
-      fprintf(stderr, "\n%s Camera App %s\n\n", basename(argv[0]), VERSION_STRING);
-
+      print_app_details(stderr);
       dump_status(&state);
    }
 

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -57,8 +57,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include <errno.h>
 
-#define VERSION_STRING "v1.3.7"
-
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"
 
@@ -1094,7 +1092,7 @@ int main(int argc, const char **argv)
 
    if (state.common_settings.verbose)
    {
-      fprintf(stderr, "\n%s Camera App %s\n\n", basename(get_app_name()), VERSION_STRING);
+      print_app_details(stderr);
       dump_status(&state);
    }
 

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -67,8 +67,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <arpa/inet.h>
 #include <time.h>
 
-#define VERSION_STRING "v1.3.12"
-
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"
 
@@ -505,8 +503,6 @@ static void dump_status(RASPIVID_STATE *state)
 static void application_help_message(char *app_name)
 {
    int i;
-
-   fprintf(stdout, "\n%s Camera App %s\n\n", basename(app_name), VERSION_STRING);
 
    fprintf(stdout, "Display camera output to display, and optionally saves an H264 capture at requested bitrate\n\n");
    fprintf(stdout, "\nusage: %s [options]\n\n", app_name);
@@ -2403,7 +2399,7 @@ int main(int argc, const char **argv)
 
    if (state.common_settings.verbose)
    {
-      fprintf(stderr, "\n%s Camera App %s\n\n", basename(argv[0]), VERSION_STRING);
+      print_app_details(stderr);
       dump_status(&state);
    }
 

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -64,8 +64,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#define VERSION_STRING "v1.3.15"
-
 #include "bcm_host.h"
 #include "interface/vcos/vcos.h"
 
@@ -1230,7 +1228,7 @@ int main(int argc, const char **argv)
 
    if (state.common_settings.verbose)
    {
-      fprintf(stderr, "\n%s Camera App %s\n\n", basename(get_app_name()), VERSION_STRING);
+      print_app_details(stderr);
       dump_status(&state);
    }
 


### PR DESCRIPTION
Changed CMakeLists.txt for the camera apps to grab the head commit
hash and pass it to the compiler as a define. Use this to version
the apps rather than the never updated version number.