### PR TITLE
Add GPS annotation to the raspivid output

### DIFF
--- a/host_applications/linux/apps/raspicam/CMakeLists.txt
+++ b/host_applications/linux/apps/raspicam/CMakeLists.txt
@@ -43,9 +43,11 @@ set (COMMON_SOURCES
    RaspiCLI.c
    RaspiPreview.c
    RaspiCommonSettings.c
-   RaspiHelpers.c)
+   RaspiHelpers.c
+   RaspiGPS.c
+   libgps_loader.c)
 
-add_executable(raspistill ${COMMON_SOURCES} RaspiStill.c  RaspiTex.c RaspiTexUtil.c tga.c ${GL_SCENE_SOURCES} libgps_loader.c)
+add_executable(raspistill ${COMMON_SOURCES} RaspiStill.c  RaspiTex.c RaspiTexUtil.c tga.c ${GL_SCENE_SOURCES} )
 add_executable(raspiyuv   ${COMMON_SOURCES} RaspiStillYUV.c)
 add_executable(raspivid   ${COMMON_SOURCES} RaspiVid.c)
 add_executable(raspividyuv  ${COMMON_SOURCES} RaspiVidYUV.c)

--- a/host_applications/linux/apps/raspicam/RaspiCommonSettings.c
+++ b/host_applications/linux/apps/raspicam/RaspiCommonSettings.c
@@ -55,6 +55,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RaspiCommonSettings.h"
 #include "RaspiCLI.h"
 #include "RaspiHelpers.h"
+#include "RaspiGPS.h"
 
 enum
 {
@@ -65,6 +66,7 @@ enum
    CommandVerbose,
    CommandCamSelect,
    CommandSensorMode,
+   CommandGpsd,
 };
 
 
@@ -77,6 +79,7 @@ static COMMAND_LIST cmdline_commands[] =
    { CommandVerbose, "-verbose",    "v",  "Output verbose information during run", 0 },
    { CommandCamSelect, "-camselect","cs", "Select camera <number>. Default 0", 1 },
    { CommandSensorMode,"-mode",     "md", "Force sensor mode. 0=auto. See docs for other modes available", 1},
+   { CommandGpsd,    "-gpsdexif",   "gps","Apply real-time GPS information to output (e.g. EXIF in JPG, annotation in video (requires " LIBGPS_SO_VERSION ")", 0},
 };
 
 static int cmdline_commands_size = sizeof(cmdline_commands) / sizeof(cmdline_commands[0]);
@@ -92,6 +95,7 @@ void raspicommonsettings_set_defaults(RASPICOMMONSETTINGS_PARAMETERS *state)
    state->verbose = 0;
    state->cameraNum = 0;
    state->sensor_mode = 0;
+   state->gps = 0;
 };
 
 /**
@@ -106,6 +110,7 @@ void raspicommonsettings_dump_parameters(RASPICOMMONSETTINGS_PARAMETERS *state)
    fprintf(stderr, "Width %d, Height %d, filename %s\n", state->width,
            state->height, state->filename);
    fprintf(stderr, "Using camera %d, sensor mode %d\n\n", state->cameraNum, state->sensor_mode);
+   fprintf(stderr, "GPS output %s\n\n", state->gps ? "Enabled" : "Disabled");
 };
 
 /**
@@ -210,6 +215,11 @@ int raspicommonsettings_parse_cmdline(RASPICOMMONSETTINGS_PARAMETERS *state, con
          used = 2;
       break;
    }
+
+   case CommandGpsd:
+      state->gps = 1;
+      used = 1;
+      break;
    }
 
    return used;

--- a/host_applications/linux/apps/raspicam/RaspiGPS.c
+++ b/host_applications/linux/apps/raspicam/RaspiGPS.c
@@ -1,0 +1,241 @@
+/*
+Copyright (c) 2018, Raspberry Pi (Trading) Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <memory.h>
+#include <errno.h>
+#include <math.h>
+
+#include "RaspiGPS.h"
+
+typedef struct
+{
+   pthread_mutex_t gps_cache_mutex;
+   gpsd_info gpsd;
+   struct gps_data_t gpsdata_cache;
+   time_t last_valid_time;
+   pthread_t gps_reader_thread;
+   int terminated;
+   int gps_reader_thread_ok;
+} GPS_READER_DATA;
+
+static GPS_READER_DATA gps_reader_data;
+
+#define GPS_CACHE_EXPIRY      5 // in seconds
+
+struct gps_data_t *raspi_gps_lock()
+{
+   pthread_mutex_lock(&gps_reader_data.gps_cache_mutex);
+   return &gps_reader_data.gpsdata_cache;
+}
+
+void raspi_gps_unlock()
+{
+   pthread_mutex_unlock(&gps_reader_data.gps_cache_mutex);
+}
+
+static void *gps_reader_process(void *gps_reader_data_ptr)
+{
+   while (!gps_reader_data.terminated)
+   {
+      int ret = 0;
+      int gps_valid = 0;
+
+      gps_reader_data.gpsd.gpsdata.set = 0;
+      gps_reader_data.gpsd.gpsdata.fix.mode = 0;
+      if (connect_gpsd(&gps_reader_data.gpsd) < 0 ||
+            (ret = read_gps_data_once(&gps_reader_data.gpsd)) < 0 )
+         break;
+
+      if (ret > 0 && gps_reader_data.gpsd.gpsdata.online)
+      {
+         if (gps_reader_data.gpsd.gpsdata.fix.mode >= MODE_2D)
+         {
+            // we have GPS fix, copy fresh data to cache
+            gps_valid = 1;
+            time(&gps_reader_data.last_valid_time);
+            pthread_mutex_lock(&gps_reader_data.gps_cache_mutex);
+            memcpy(&gps_reader_data.gpsdata_cache, &gps_reader_data.gpsd.gpsdata,
+                   sizeof(struct gps_data_t));
+            pthread_mutex_unlock(&gps_reader_data.gps_cache_mutex);
+         }
+      }
+      if (!gps_valid)
+      {
+         time_t now;
+         time(&now);
+         if (now - gps_reader_data.last_valid_time > GPS_CACHE_EXPIRY)
+         {
+            // our cache is stale, clear it
+            pthread_mutex_lock(&gps_reader_data.gps_cache_mutex);
+            gps_reader_data.gpsdata_cache.online = gps_reader_data.gpsd.gpsdata.online;
+            gps_reader_data.gpsdata_cache.set = 0;
+            gps_reader_data.gpsdata_cache.fix.mode = 0;
+            pthread_mutex_unlock(&gps_reader_data.gps_cache_mutex);
+         }
+         // we lost GPS fix, copy GPS time to cache if available
+         if (gps_reader_data.gpsd.gpsdata.set & TIME_SET)
+         {
+            pthread_mutex_lock(&gps_reader_data.gps_cache_mutex);
+            gps_reader_data.gpsdata_cache.set |= TIME_SET;
+            gps_reader_data.gpsdata_cache.fix.time = gps_reader_data.gpsd.gpsdata.fix.time;
+            pthread_mutex_unlock(&gps_reader_data.gps_cache_mutex);
+         }
+      }
+   }
+   return NULL;
+}
+
+void raspi_gps_shutdown(int verbose)
+{
+   gps_reader_data.terminated = 1;
+
+   if (gps_reader_data.gps_reader_thread_ok)
+   {
+      if (verbose)
+         fprintf(stderr, "Waiting for GPS reader thread to terminate\n");
+
+      pthread_join(gps_reader_data.gps_reader_thread, NULL);
+   }
+   if (verbose && gps_reader_data.gpsd.gpsd_connected)
+      fprintf(stderr, "Closing gpsd connection\n\n");
+
+   disconnect_gpsd(&gps_reader_data.gpsd);
+
+   libgps_unload(&gps_reader_data.gpsd);
+
+   pthread_mutex_destroy(&gps_reader_data.gps_cache_mutex);
+}
+
+int raspi_gps_setup(int verbose)
+{
+   memset(&gps_reader_data, 0, sizeof(gps_reader_data));
+
+   pthread_mutex_init(&gps_reader_data.gps_cache_mutex, NULL);
+
+   gpsd_init(&gps_reader_data.gpsd);
+   if (libgps_load(&gps_reader_data.gpsd))
+   {
+      pthread_mutex_destroy(&gps_reader_data.gps_cache_mutex);
+      fprintf(stderr, "Unable to load the libGPS library");
+      return -1;
+   }
+   if (verbose)
+      fprintf(stderr, "Connecting to gpsd @ %s:%s\n",
+              gps_reader_data.gpsd.server, gps_reader_data.gpsd.port);
+
+   if (connect_gpsd(&gps_reader_data.gpsd))
+   {
+      fprintf(stderr, "no gpsd running or network error: %d, %s\n",
+              errno, gps_reader_data.gpsd.gps_errstr(errno));
+
+      libgps_unload(&gps_reader_data.gpsd);
+
+      pthread_mutex_destroy(&gps_reader_data.gps_cache_mutex);
+
+      return -1;
+   }
+   if (verbose)
+      fprintf(stderr, "Waiting for GPS time\n");
+
+   if (wait_gps_time(&gps_reader_data.gpsd, 2))
+   {
+      if (verbose)
+         fprintf(stderr, "Warning: GPS time not available\n");
+   }
+   if (verbose)
+      fprintf(stderr, "Creating GPS reader thread\n");
+
+   if (pthread_create(&gps_reader_data.gps_reader_thread, NULL,
+                      gps_reader_process, &gps_reader_data))
+   {
+      fprintf(stderr, "Error creating GPS reader thread\n");
+      gps_reader_data.terminated = 1;
+      raspi_gps_shutdown(verbose);
+      return -1;
+   }
+
+   gps_reader_data.gps_reader_thread_ok = 1;
+   return 0;
+}
+
+char *raspi_gps_location_string()
+{
+   char lat[24] = {"n/a"};
+   char lon[24] = {"n/a"};
+   char alt[24] = {"Altitude n/a"};
+   char speed[24] = {"Speed n/a"};
+   char track[24] = {"Track n/a"};
+   char datetime[32] = {"Time n/a"};
+   char *text;
+
+   struct gps_data_t *gpsdata = raspi_gps_lock();
+
+   if (gpsdata->set & TIME_SET)
+   {
+      time_t rawtime;
+      struct tm *timeinfo;
+      rawtime = gpsdata->fix.time;
+      timeinfo = localtime(&rawtime);
+      strftime(datetime, sizeof(datetime), "%Y:%m:%d %H:%M:%S", timeinfo);
+   }
+
+   if (gpsdata->online && gpsdata->fix.mode >= MODE_2D)
+   {
+      if (gpsdata->set & LATLON_SET)
+      {
+         if (!isnan(gpsdata->fix.latitude))
+            snprintf(lat, sizeof(lat), "%.6lf", gpsdata->fix.latitude);
+
+         if (!isnan(gpsdata->fix.longitude))
+            snprintf(lon, sizeof(lon), "%.6lf", gpsdata->fix.longitude);
+      }
+
+      if ((gpsdata->set & ALTITUDE_SET) && (gpsdata->fix.mode >= MODE_3D) &&
+            (!isnan(gpsdata->fix.altitude)))
+      {
+         snprintf(alt, sizeof(alt), "Altitude=%.2fm", gpsdata->fix.altitude);
+      }
+
+      if ((gpsdata->set & SPEED_SET) && !isnan(gpsdata->fix.speed))
+      {
+         snprintf(speed, sizeof(speed), "Speed=%.2fkph", gpsdata->fix.speed*MPS_TO_KPH);
+      }
+
+      if ((gpsdata->set & TRACK_SET) && !isnan(gpsdata->fix.track))
+      {
+         snprintf(track, sizeof(track), "Track=%.2f", gpsdata->fix.track);
+      }
+   }
+   raspi_gps_unlock();
+
+   asprintf(&text,  "%s Lat %s Long %s %s %s %s", datetime, lat, lon, alt, speed, track);
+
+   return text;
+}

--- a/host_applications/linux/apps/raspicam/RaspiGPS.h
+++ b/host_applications/linux/apps/raspicam/RaspiGPS.h
@@ -25,35 +25,23 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/**
- * \file RaspiCommonSettings.c
- *
- * Description
- *
- * Handles general settings applicable to all the camera applications
- */
+#ifndef RASPIGPS_H_
+#define RASPIGPS_H_
 
-#ifndef RASPIGENERALSETTINGS_H_
-#define RASPIGENERALSETTINGS_H_
+#include <pthread.h>
+#include <time.h>
 
-#include "interface/mmal/mmal_parameters_camera.h"
+#include "libgps_loader.h"
 
-typedef struct
-{
-   char camera_name[MMAL_PARAMETER_CAMERA_INFO_MAX_STR_LEN]; // Name of the camera sensor
-   int width;                          /// Requested width of image
-   int height;                         /// requested height of image
-   char *filename;                     /// filename of output file
-   int cameraNum;                      /// Camera number
-   int sensor_mode;                    /// Sensor mode. 0=auto. Check docs/forum for modes selected by other values.
-   int verbose;                        /// !0 if want detailed run information
-   int gps;                            /// Add real-time gpsd output to output
+int raspi_gps_setup(int verbose);
+void raspi_gps_shutdown(int verbose);
 
-} RASPICOMMONSETTINGS_PARAMETERS;
+struct gps_data_t *raspi_gps_lock();
+void raspi_gps_unlock();
 
-void raspicommonsettings_set_defaults(RASPICOMMONSETTINGS_PARAMETERS *);
-void raspicommonsettings_dump_parameters(RASPICOMMONSETTINGS_PARAMETERS *);
-void raspicommonsettings_display_help();
-int raspicommonsettings_parse_cmdline(RASPICOMMONSETTINGS_PARAMETERS *state, const char *arg1, const char *arg2, void (*app_help)());
+// Return string representation of the current fix
+// The resulting pointer is allocated so will
+// need to be freed when finished with.
+char *raspi_gps_location_string();
 
-#endif
+#endif /* RASPIGPS_H_ */

--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -77,7 +77,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RaspiTex.h"
 #include "RaspiHelpers.h"
 
-#include "libgps_loader.h"
+// TODO
+//#include "libgps_loader.h"
+
+#include "RaspiGPS.h"
 
 #include <semaphore.h>
 #include <math.h>
@@ -88,7 +91,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MMAL_CAMERA_PREVIEW_PORT 0
 #define MMAL_CAMERA_VIDEO_PORT 1
 #define MMAL_CAMERA_CAPTURE_PORT 2
-
 
 // Stills format information
 // 0 implies variable
@@ -143,7 +145,6 @@ typedef struct
    int datetime;                       /// Use DateTime instead of frame#
    int timestamp;                      /// Use timestamp instead of frame#
    int restart_interval;               /// JPEG restart interval. 0 for none.
-   int gpsdExif;                       /// Add real-time gpsd output as EXIF tags
 
    RASPIPREVIEW_PARAMETERS preview_parameters;    /// Preview setup parameters
    RASPICAM_CAMERA_PARAMETERS camera_parameters; /// Camera setup parameters
@@ -169,21 +170,6 @@ typedef struct
    RASPISTILL_STATE *pstate;            /// pointer to our state in case required in callback
 } PORT_USERDATA;
 
-typedef struct
-{
-   pthread_mutex_t gps_cache_mutex;
-   gpsd_info gpsd;
-   struct gps_data_t gpsdata_cache;
-   time_t last_valid_time;
-   pthread_t gps_reader_thread;
-   RASPISTILL_STATE *pstate;            /// pointer to our state
-   int terminated;
-   int gps_reader_thread_ok;
-} GPS_READER_DATA;
-static GPS_READER_DATA gps_reader_data;
-
-#define GPS_CACHE_EXPIRY      5 // in seconds
-
 static void store_exif_tag(RASPISTILL_STATE *state, const char *exif_tag);
 
 /// Command ID's and Structure defining our command line options
@@ -208,7 +194,6 @@ enum
    CommandTimeStamp,
    CommandFrameStart,
    CommandRestartInterval,
-   CommandGpsdExif
 };
 
 static COMMAND_LIST cmdline_commands[] =
@@ -232,7 +217,6 @@ static COMMAND_LIST cmdline_commands[] =
    { CommandTimeStamp, "-timestamp", "ts", "Replace output pattern (%d) with unix timestamp (seconds since 1970)", 0},
    { CommandFrameStart,"-framestart","fs",  "Starting frame number in output pattern(%d)", 1},
    { CommandRestartInterval, "-restart","rs","JPEG Restart interval (default of 0 for none)", 1},
-   { CommandGpsdExif,  "-gpsdexif", "gps", "Apply real-time GPS information from gpsd as EXIF tags (requires "LIBGPS_SO_VERSION")", 0},
 };
 
 static int cmdline_commands_size = sizeof(cmdline_commands) / sizeof(cmdline_commands[0]);
@@ -316,7 +300,6 @@ static void default_status(RASPISTILL_STATE *state)
    state->datetime = 0;
    state->timestamp = 0;
    state->restart_interval = 0;
-   state->gpsdExif = 0;
 
    // Setup preview window defaults
    raspipreview_set_defaults(&state->preview_parameters);
@@ -652,10 +635,6 @@ static int parse_cmdline(int argc, const char **argv, RASPISTILL_STATE *state)
             valid = 0;
          break;
       }
-
-      case CommandGpsdExif:
-         state->gpsdExif = 1;
-         break;
 
       default:
       {
@@ -1260,7 +1239,7 @@ static void add_exif_tags(RASPISTILL_STATE *state, struct gps_data_t *gpsdata)
 
 
    // Add GPS tags
-   if (state->gpsdExif)
+   if (state->common_settings.gps)
    {
       // clear all existing tags first
       add_exif_tag(state, "GPS.GPSDateStamp=");
@@ -1278,7 +1257,6 @@ static void add_exif_tags(RASPISTILL_STATE *state, struct gps_data_t *gpsdata)
       add_exif_tag(state, "GPS.GPSTrack=");
       add_exif_tag(state, "GPS.GPSTrackRef=");
 
-      pthread_mutex_lock(&gps_reader_data.gps_cache_mutex);
       if (gpsdata->online)
       {
          if (state->common_settings.verbose)
@@ -1375,7 +1353,6 @@ static void add_exif_tags(RASPISTILL_STATE *state, struct gps_data_t *gpsdata)
             }
          }
       }
-      pthread_mutex_unlock(&gps_reader_data.gps_cache_mutex);
    }
 
    // Now send any user supplied tags
@@ -1652,57 +1629,6 @@ static void rename_file(RASPISTILL_STATE *state, FILE *output_file,
    }
 }
 
-void *gps_reader_process(void *gps_reader_data_ptr)
-{
-   GPS_READER_DATA *gps_reader = (GPS_READER_DATA *)gps_reader_data_ptr;
-   while (!gps_reader->terminated)
-   {
-      int ret = 0;
-      gps_reader->gpsd.gpsdata.set = 0;
-      gps_reader->gpsd.gpsdata.fix.mode = 0;
-      if ((connect_gpsd(&gps_reader->gpsd) < 0) ||
-            ((ret = read_gps_data_once(&gps_reader->gpsd)) < 0))
-         break;
-
-      int gps_valid = 0;
-      if ((ret > 0) && (gps_reader->gpsd.gpsdata.online))
-      {
-         if (gps_reader->gpsd.gpsdata.fix.mode >= MODE_2D)
-         {
-            // we have GPS fix, copy fresh data to cache
-            gps_valid = 1;
-            time(&gps_reader->last_valid_time);
-            pthread_mutex_lock(&gps_reader->gps_cache_mutex);
-            memcpy(&gps_reader->gpsdata_cache, &gps_reader->gpsd.gpsdata,
-                   sizeof(struct gps_data_t));
-            pthread_mutex_unlock(&gps_reader->gps_cache_mutex);
-         }
-      }
-      if (!gps_valid)
-      {
-         time_t now;
-         time(&now);
-         if (now - gps_reader->last_valid_time > GPS_CACHE_EXPIRY)
-         {
-            // our cache is stale, clear it
-            pthread_mutex_lock(&gps_reader->gps_cache_mutex);
-            gps_reader->gpsdata_cache.online = gps_reader->gpsd.gpsdata.online;
-            gps_reader->gpsdata_cache.set = 0;
-            gps_reader->gpsdata_cache.fix.mode = 0;
-            pthread_mutex_unlock(&gps_reader->gps_cache_mutex);
-         }
-         // we lost GPS fix, copy GPS time to cache if available
-         if (gps_reader->gpsd.gpsdata.set & TIME_SET)
-         {
-            pthread_mutex_lock(&gps_reader->gps_cache_mutex);
-            gps_reader->gpsdata_cache.set |= TIME_SET;
-            gps_reader->gpsdata_cache.fix.time = gps_reader->gpsd.gpsdata.fix.time;
-            pthread_mutex_unlock(&gps_reader->gps_cache_mutex);
-         }
-      }
-   }
-   return NULL;
-}
 
 /**
  * main
@@ -1762,47 +1688,10 @@ int main(int argc, const char **argv)
       dump_status(&state);
    }
 
-   if (state.gpsdExif)
+   if (state.common_settings.gps)
    {
-      memset(&gps_reader_data, 0, sizeof(gps_reader_data));
-      pthread_mutex_init(&gps_reader_data.gps_cache_mutex, NULL);
-      gps_reader_data.pstate = &state;
-
-      gpsd_init(&gps_reader_data.gpsd);
-      if (libgps_load(&gps_reader_data.gpsd))
-      {
-         pthread_mutex_destroy(&gps_reader_data.gps_cache_mutex);
-         exit(EX_SOFTWARE);
-      }
-      if (state.common_settings.verbose)
-         fprintf(stderr, "Connecting to gpsd @ %s:%s\n",
-                 gps_reader_data.gpsd.server, gps_reader_data.gpsd.port);
-      if (connect_gpsd(&gps_reader_data.gpsd))
-      {
-         fprintf(stderr, "no gpsd running or network error: %d, %s\n",
-                 errno, gps_reader_data.gpsd.gps_errstr(errno));
-         libgps_unload(&gps_reader_data.gpsd);
-         pthread_mutex_destroy(&gps_reader_data.gps_cache_mutex);
-         exit(EX_SOFTWARE);
-      }
-      if (state.common_settings.verbose)
-         fprintf(stderr, "Waiting for GPS time\n");
-      if (wait_gps_time(&gps_reader_data.gpsd, 2))
-      {
-         if (state.common_settings.verbose)
-            fprintf(stderr, "Warning: GPS time not available\n");
-      }
-      if (state.common_settings.verbose)
-         fprintf(stderr, "Creating GPS reader thread\n");
-      if (pthread_create(&gps_reader_data.gps_reader_thread, NULL,
-                         gps_reader_process, &gps_reader_data))
-      {
-         fprintf(stderr, "Error creating GPS reader thread\n");
-         exit_code = EX_SOFTWARE;
-         gps_reader_data.terminated = 1;
-         goto gps_error;
-      }
-      gps_reader_data.gps_reader_thread_ok = 1;
+      if (raspi_gps_setup(state.common_settings.verbose))
+         state.common_settings.gps = false;
    }
 
    if (state.useGL)
@@ -1988,7 +1877,9 @@ int main(int argc, const char **argv)
                   // once enabled no further exif data is accepted
                   if ( state.enableExifTags )
                   {
-                     add_exif_tags(&state, &gps_reader_data.gpsdata_cache);
+                     struct gps_data_t *gps_data = raspi_gps_lock();
+                     add_exif_tags(&state, gps_data);
+                     raspi_gps_unlock();
                   }
                   else
                   {
@@ -2039,15 +1930,32 @@ int main(int argc, const char **argv)
                   }
 
                   if(state.camera_parameters.enable_annotate)
-                     raspicamcontrol_set_annotate(state.camera_component, state.camera_parameters.enable_annotate,
-                                                  state.camera_parameters.annotate_string,
-                                                  state.camera_parameters.annotate_text_size,
-                                                  state.camera_parameters.annotate_text_colour,
-                                                  state.camera_parameters.annotate_bg_colour,
-                                                  state.camera_parameters.annotate_justify,
-                                                  state.camera_parameters.annotate_x,
-                                                  state.camera_parameters.annotate_y
-                                                 );
+                  {
+                     if ((state.camera_parameters.enable_annotate & ANNOTATE_APP_TEXT) && state.common_settings.gps)
+                     {
+                        char *text = raspi_gps_location_string();
+                        raspicamcontrol_set_annotate(state.camera_component, state.camera_parameters.enable_annotate,
+                                                     text,
+                                                     state.camera_parameters.annotate_text_size,
+                                                     state.camera_parameters.annotate_text_colour,
+                                                     state.camera_parameters.annotate_bg_colour,
+                                                     state.camera_parameters.annotate_justify,
+                                                     state.camera_parameters.annotate_x,
+                                                     state.camera_parameters.annotate_y
+                                                    );
+                        free(text);
+                     }
+                     else
+                        raspicamcontrol_set_annotate(state.camera_component, state.camera_parameters.enable_annotate,
+                                                     state.camera_parameters.annotate_string,
+                                                     state.camera_parameters.annotate_text_size,
+                                                     state.camera_parameters.annotate_text_colour,
+                                                     state.camera_parameters.annotate_bg_colour,
+                                                     state.camera_parameters.annotate_justify,
+                                                     state.camera_parameters.annotate_x,
+                                                     state.camera_parameters.annotate_y
+                                                    );
+                  }
 
                   if (state.common_settings.verbose)
                      fprintf(stderr, "Starting capture %d\n", frame);
@@ -2125,7 +2033,6 @@ error:
       if (state.encoder_connection)
          mmal_connection_destroy(state.encoder_connection);
 
-
       /* Disable components */
       if (state.encoder_component)
          mmal_component_disable(state.encoder_component);
@@ -2142,23 +2049,9 @@ error:
 
       if (state.common_settings.verbose)
          fprintf(stderr, "Close down completed, all components disconnected, disabled and destroyed\n\n");
-   }
 
-gps_error:
-   if (state.gpsdExif)
-   {
-      gps_reader_data.terminated = 1;
-      if (gps_reader_data.gps_reader_thread_ok)
-      {
-         if (state.common_settings.verbose)
-            fprintf(stderr, "Waiting for GPS reader thread to terminate\n");
-         pthread_join(gps_reader_data.gps_reader_thread, NULL);
-      }
-      if ((state.common_settings.verbose) && (gps_reader_data.gpsd.gpsd_connected))
-         fprintf(stderr, "Closing gpsd connection\n\n");
-      disconnect_gpsd(&gps_reader_data.gpsd);
-      libgps_unload(&gps_reader_data.gpsd);
-      pthread_mutex_destroy(&gps_reader_data.gps_cache_mutex);
+      if (state.common_settings.gps)
+         raspi_gps_shutdown(state.common_settings.verbose);
    }
 
    if (status != MMAL_SUCCESS)

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -80,6 +80,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RaspiPreview.h"
 #include "RaspiCLI.h"
 #include "RaspiHelpers.h"
+#include "RaspiGPS.h"
 
 #include <semaphore.h>
 
@@ -717,6 +718,7 @@ static void camera_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buff
    // We pass our file handle and other stuff in via the userdata field.
 
    PORT_USERDATA *pData = (PORT_USERDATA *)port->userdata;
+   RASPIVIDYUV_STATE *pstate = pData->pstate;
 
    if (pData)
    {
@@ -724,7 +726,7 @@ static void camera_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buff
       int bytes_to_write = buffer->length;
       int64_t current_time = vcos_getmicrosecs64()/1000000;
 
-      if (pData->pstate->onlyLuma)
+      if (pstate->onlyLuma)
          bytes_to_write = vcos_min(buffer->length, port->format->es->video.width * port->format->es->video.height);
 
       vcos_assert(pData->file_handle);
@@ -751,8 +753,8 @@ static void camera_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buff
             if(buffer->pts != MMAL_TIME_UNKNOWN)
             {
                int64_t pts;
-               if(pData->pstate->frame==0)
-                  pData->pstate->starttime=buffer->pts;
+               if(pstate->frame==0)
+                  pstate->starttime=buffer->pts;
                pData->lasttime=buffer->pts;
                pts = buffer->pts - pData->starttime;
                fprintf(pData->pts_file_handle,"%lld.%03lld\n", pts/1000, pts%1000);
@@ -764,16 +766,30 @@ static void camera_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buff
       // See if the second count has changed and we need to update any annotation
       if (current_time != last_second)
       {
-         raspicamcontrol_set_annotate(pData->pstate->camera_component,
-                                      pData->pstate->camera_parameters.enable_annotate,
-                                      pData->pstate->camera_parameters.annotate_string,
-                                      pData->pstate->camera_parameters.annotate_text_size,
-                                      pData->pstate->camera_parameters.annotate_text_colour,
-                                      pData->pstate->camera_parameters.annotate_bg_colour,
-                                      pData->pstate->camera_parameters.annotate_justify,
-                                      pData->pstate->camera_parameters.annotate_x,
-                                      pData->pstate->camera_parameters.annotate_y
-                                      );
+         if ((pstate->camera_parameters.enable_annotate & ANNOTATE_APP_TEXT) && pstate->common_settings.gps)
+         {
+            char *text = raspi_gps_location_string();
+            raspicamcontrol_set_annotate(pstate->camera_component, pstate->camera_parameters.enable_annotate,
+                                         text,
+                                         pstate->camera_parameters.annotate_text_size,
+                                         pstate->camera_parameters.annotate_text_colour,
+                                         pstate->camera_parameters.annotate_bg_colour,
+                                         pstate->camera_parameters.annotate_justify,
+                                         pstate->camera_parameters.annotate_x,
+                                         pstate->camera_parameters.annotate_y
+                                        );
+            free(text);
+         }
+         else
+            raspicamcontrol_set_annotate(pstate->camera_component, pstate->camera_parameters.enable_annotate,
+                                         pstate->camera_parameters.annotate_string,
+                                         pstate->camera_parameters.annotate_text_size,
+                                         pstate->camera_parameters.annotate_text_colour,
+                                         pstate->camera_parameters.annotate_bg_colour,
+                                         pstate->camera_parameters.annotate_justify,
+                                         pstate->camera_parameters.annotate_x,
+                                         pstate->camera_parameters.annotate_y
+                                        );
          last_second = current_time;
       }
 
@@ -1254,6 +1270,10 @@ int main(int argc, const char **argv)
       dump_status(&state);
    }
 
+   if (state.common_settings.gps)
+      if (raspi_gps_setup(state.common_settings.verbose))
+         state.common_settings.gps = false;
+
    // OK, we have a nice set of parameters. Now set up our components
    // We have two components. Camera, Preview
 
@@ -1471,6 +1491,9 @@ error:
 
       raspipreview_destroy(&state.preview_parameters);
       destroy_camera_component(&state);
+
+      if (state.common_settings.gps)
+         raspi_gps_shutdown(state.common_settings.verbose);
 
       if (state.common_settings.verbose)
          fprintf(stderr, "Close down completed, all components disconnected, disabled and destroyed\n\n");


### PR DESCRIPTION
This involved:
Moving GPS code to own file so can be used in all apps
Adding option in raspivid to apply GPS data to annotation
  Enabled with the -gps flag on command line plus -a 2 to turn on
  application annotation.