### PR TITLE
well-tested compiler flags essential to gain useful backtrace(3) result

### DIFF
--- a/makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake
+++ b/makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake
@@ -14,7 +14,7 @@ add_definitions("-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -marm")
 
 # rdynamic means the backtrace should work
 IF (CMAKE_BUILD_TYPE MATCHES "Debug")
-   add_definitions(-rdynamic)
+   add_definitions(-rdynamic -O0 -g3 -funwind-tables)
 ENDIF()
 
 # avoids annoying and pointless warnings from gcc


### PR DESCRIPTION
without this patch call to backtrace(3) returns zero.

Tested on RPiZ without analog/digital gain control support in ThreadX API:

Output of modified `raspistill -o /dev/null -awb off -awbg 1.56,1.78 -ex off -ag 1 -dg 1 -t 1 -v` before and after patch:

```diff
-Obtained 0 stack frames.
+Obtained 7 stack frames.
+./raspistill(print_trace+0x1c) [0x11bcc]
+./raspistill(mmal_status_to_int+0x30) [0x12184]
+./raspistill(raspicamcontrol_set_gains+0x88) [0x1048c]
+./raspistill(raspicamcontrol_set_all_parameters+0x39c) [0xeef8]
+./raspistill() [0x1561c]
+./raspistill(main+0x228) [0x1798c]
+/lib/arm-linux-gnueabihf/libc.so.6(__libc_start_main+0x114) [0xb6c18678]
mmal: Function not implemented
```

`raspistill` modification (just for test, not included in this pull request):

```diff
diff --git a/host_applications/linux/apps/raspicam/RaspiHelpers.c b/host_applications/linux/apps/raspicam/RaspiHelpers.c
index 5c25e18..86e113e 100644
--- a/host_applications/linux/apps/raspicam/RaspiHelpers.c
+++ b/host_applications/linux/apps/raspicam/RaspiHelpers.c
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include <stdint.h>
 
+#include <execinfo.h>
 
 #include "interface/vcos/vcos.h"
 #include "interface/mmal/mmal.h"
@@ -58,6 +59,25 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static const char *app_name;
 
+/* Obtain a backtrace and print it to stdout. */
+void print_trace (void)
+{
+  void *array[10];
+  size_t size;
+  char **strings;
+  size_t i;
+
+  size = backtrace (array, 10);
+  strings = backtrace_symbols (array, size);
+
+  printf ("Obtained %zd stack frames.\n", size);
+
+  for (i = 0; i < size; i++)
+     printf ("%s\n", strings[i]);
+
+  free (strings);
+}
+
 void print_app_details(FILE *fd)
 {
    if (!app_name)
@@ -225,6 +245,7 @@ int mmal_status_to_int(MMAL_STATUS_T status)
       return 0;
    else
    {
+         print_trace();
       switch (status)
       {
       case MMAL_ENOMEM :
```
