### PR TITLE
Move to standard Linux  microsecond count

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiHelpers.c
+++ b/host_applications/linux/apps/raspicam/RaspiHelpers.c
@@ -280,3 +280,17 @@ int mmal_status_to_int(MMAL_STATUS_T status)
       return 1;
    }
 }
+
+
+uint64_t get_microseconds64()
+{
+   struct timespec spec;
+   uint64_t us;
+
+   clock_gettime(CLOCK_MONOTONIC_RAW, &spec);
+
+   us = spec.tv_sec * 1000000;
+   us += spec.tv_nsec / 1000;
+
+   return us;
+}

--- a/host_applications/linux/apps/raspicam/RaspiHelpers.h
+++ b/host_applications/linux/apps/raspicam/RaspiHelpers.h
@@ -38,5 +38,6 @@ void check_disable_port(MMAL_PORT_T *port);
 void default_signal_handler(int signal_number);
 int mmal_status_to_int(MMAL_STATUS_T status);
 void print_app_details(FILE *fd);
+uint64_t get_microseconds64();
 
 #endif

--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1427,7 +1427,7 @@ static int wait_for_next_frame(RASPISTILL_STATE *state, int *frame)
    static int64_t complete_time = -1;
    int keep_running = 1;
 
-   int64_t current_time =  vcos_getmicrosecs64()/1000;
+   int64_t current_time =  get_microseconds64()/1000;
 
    if (complete_time == -1)
       complete_time =  current_time + state->timeout;
@@ -1467,7 +1467,7 @@ static int wait_for_next_frame(RASPISTILL_STATE *state, int *frame)
          vcos_sleep(CAMERA_SETTLE_TIME);
 
          // Update our current time after the sleep
-         current_time =  vcos_getmicrosecs64()/1000;
+         current_time =  get_microseconds64()/1000;
 
          // Set our initial 'next frame time'
          next_frame_ms = current_time + state->timelapse;

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -847,7 +847,7 @@ static int wait_for_next_frame(RASPISTILLYUV_STATE *state, int *frame)
    static int64_t complete_time = -1;
    int keep_running = 1;
 
-   int64_t current_time =  vcos_getmicrosecs64()/1000;
+   int64_t current_time =  get_microseconds64()/1000;
 
    if (complete_time == -1)
       complete_time =  current_time + state->timeout;
@@ -887,7 +887,7 @@ static int wait_for_next_frame(RASPISTILLYUV_STATE *state, int *frame)
          vcos_sleep(CAMERA_SETTLE_TIME);
 
          // Update our current time after the sleep
-         current_time =  vcos_getmicrosecs64()/1000;
+         current_time =  get_microseconds64()/1000;
 
          // Set our initial 'next frame time'
          next_frame_ms = current_time + state->timelapse;

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1210,7 +1210,7 @@ static void encoder_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
 
    // All our segment times based on the receipt of the first encoder callback
    if (base_time == -1)
-      base_time = vcos_getmicrosecs64()/1000;
+      base_time = get_microseconds64()/1000;
 
    // We pass our file handle and other stuff in via the userdata field.
 
@@ -1219,7 +1219,7 @@ static void encoder_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
    if (pData)
    {
       int bytes_written = buffer->length;
-      int64_t current_time = vcos_getmicrosecs64()/1000;
+      int64_t current_time = get_microseconds64()/1000;
 
       vcos_assert(pData->file_handle);
       if(pData->pstate->inlineMotionVectors) vcos_assert(pData->imv_file_handle);
@@ -2270,7 +2270,7 @@ static int wait_for_next_change(RASPIVID_STATE *state)
    static int64_t complete_time = -1;
 
    // Have we actually exceeded our timeout?
-   int64_t current_time =  vcos_getmicrosecs64()/1000;
+   int64_t current_time =  get_microseconds64()/1000;
 
    if (complete_time == -1)
       complete_time =  current_time + state->timeout;

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -724,7 +724,7 @@ static void camera_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buff
    {
       int bytes_written = 0;
       int bytes_to_write = buffer->length;
-      int64_t current_time = vcos_getmicrosecs64()/1000000;
+      int64_t current_time = get_microseconds64()/1000000;
 
       if (pstate->onlyLuma)
          bytes_to_write = vcos_min(buffer->length, port->format->es->video.width * port->format->es->video.height);
@@ -1128,7 +1128,7 @@ static int wait_for_next_change(RASPIVIDYUV_STATE *state)
    static int64_t complete_time = -1;
 
    // Have we actually exceeded our timeout?
-   int64_t current_time =  vcos_getmicrosecs64()/1000;
+   int64_t current_time =  get_microseconds64()/1000;
 
    if (complete_time == -1)
       complete_time =  current_time + state->timeout;


### PR DESCRIPTION
The camera apps were using vcos_getmicrosecs64 which
was in turn using gettimeofday. This means timelapse code
goes very wrong when the date/time is changed while the
timelapse is being done.

Moved to a scheme based on clock_gettime(CLOCK_MONOTONIC_RAW)
which is not affected by underlying clock changes.