### PR TITLE
Allow aborting on write error to stdout when `-t 0` specified

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2287,10 +2287,10 @@ static int wait_for_next_change(RASPIVID_STATE *state)
 
    case WAIT_METHOD_FOREVER:
    {
-      // We never return from this. Expect a ctrl-c to exit.
-      while (1)
+      // We never return from this. Expect a ctrl-c to exit or abort.
+      while (!state->callback_data.abort)
          // Have a sleep so we don't hog the CPU.
-         vcos_sleep(10000);
+         vcos_sleep(ABORT_INTERVAL);
 
       return 0;
    }

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -1145,10 +1145,10 @@ static int wait_for_next_change(RASPIVIDYUV_STATE *state)
 
    case WAIT_METHOD_FOREVER:
    {
-      // We never return from this. Expect a ctrl-c to exit.
-      while (1)
-         // Have a sleep so we don't hog the CPU.
-         vcos_sleep(10000);
+      // We never return from this. Expect a ctrl-c to exit or abort.
+      while (!state->callback_data.abort)
+          // Have a sleep so we don't hog the CPU.
+         vcos_sleep(ABORT_INTERVAL);
 
       return 0;
    }


### PR DESCRIPTION
This little fix will avoid the following message when raspivid is launched by systemd when a client connect to the listenning socket AND ensure the raspivid process exit when TCP connection is closed by the client.
```
janv. 08 14:19:58 raspberrypi raspivid[4770]: mmal: Failed to write buffer data (4096 from 5016)- aborting
````
`raspivid` fail to exit because abort status isn't taken into account when `-t 0` is given in parameter.

My raspberry Pi3 use the following systemd units:
- /etc/systemd/system/raspivid.socket
```
[Unit]
Description=Raspivid Streaming Socket

[Socket]
ListenStream=3333
Accept=yes
MaxConnections=1
SendBuffer=1M

[Install]
WantedBy=sockets.target
```
- /etc/systemd/system/raspivid@.service
```
[Unit]
Description=Raspivid Streaming Instance

[Service]
ExecStart=-/usr/bin/raspivid -v -n -t 0 -w 1280 -h 720 -fl -ih -b 800000 -fps 25 -pf main -g 25 -o -
StandardInput=socket
StandardError=journal
```
