### PR TITLE
vcgencmd: add man page

### DIFF
--- a/host_applications/linux/apps/gencmd/CMakeLists.txt
+++ b/host_applications/linux/apps/gencmd/CMakeLists.txt
@@ -17,4 +17,5 @@ include_directories( ../../../..
 add_executable(vcgencmd gencmd.c)
 target_link_libraries(vcgencmd vcos vchiq_arm vchostif)
 install(TARGETS vcgencmd RUNTIME DESTINATION bin)
+install(FILES vcgencmd.1 DESTINATION /usr/man/man1)
 

--- a/host_applications/linux/apps/gencmd/vcgencmd.1
+++ b/host_applications/linux/apps/gencmd/vcgencmd.1
@@ -1,0 +1,24 @@
+.TH vcgencmd 1 "January 2019" "Raspberry Pi vcgencmd" "User Commands"
+.SH NAME
+vcgencmd - send a command to the VideoCore
+.SH SYNOPSIS
+vcgencmd [-?] | [--help] | [-t] [COMMAND]
+.SH DESCRIPTION
+Send a command to the VideoCore and display the response.
+.SH OPTIONS
+.TP
+.BR \-? ", " \-\-help\fR
+Display basic usage information
+.TP
+.BR \-t\fR
+Time how long it takes to return the result of a command
+.TP
+.BR commands \fR
+Query the VideoCore to find out what commands it supports. Newer firmwares support more commands.
+.TP
+.BR "Exit status:"
+ 0   success
+.br
+-1   problem with VCHI
+.br 
+-2   VideoCore returned an error


### PR DESCRIPTION
First bash at adding a man page.

Questions: 

1. Currently I'm using a hard-coded path as the installation directory for the man page (/usr/man/man1). This is probably wrong - any suggestions?

2. Not sure what name to put in the bottom left of the man page footer. I've gone for 'Raspberry Pi vcgencmd' as a placeholder - what should this be set to? Perhaps 'Raspberry Pi userland'? Or maybe the name of the debian package?