### PR TITLE
raspivid: Stop --raw option resetting --raw-format to YUV

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -158,7 +158,7 @@ typedef struct
  */
 typedef enum
 {
-   RAW_OUTPUT_FMT_YUV = 1,
+   RAW_OUTPUT_FMT_YUV = 0,
    RAW_OUTPUT_FMT_RGB,
    RAW_OUTPUT_FMT_GRAY,
 } RAW_OUTPUT_FMT;
@@ -876,7 +876,7 @@ static int parse_cmdline(int argc, const char **argv, RASPIVID_STATE *state)
       case CommandRaw:  // output filename
       {
          state->raw_output = 1;
-         state->raw_output_fmt = RAW_OUTPUT_FMT_YUV;
+         //state->raw_output_fmt defaults to 0 / yuv
          int len = strlen(argv[i + 1]);
          if (len)
          {


### PR DESCRIPTION
Observed on
https://www.raspberrypi.org/forums/viewtopic.php?f=43&t=189830&start=25#p1432589

The raspivid command line
raspivid --raw-format rgb --raw foo.rgb -o foo.h264
actually saved YUV data to foo.rgb as the --raw option reset
raw-format to YUV mode.

Renumber the enums so that YUV is 0, and use the fact the state
structure is memset to 0 (and therefore YUV) to avoid the
-raw parser needing to change the format at all.