### PR TITLE
Fixed up overflow in microsecond timer

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiHelpers.c
+++ b/host_applications/linux/apps/raspicam/RaspiHelpers.c
@@ -289,7 +289,7 @@ uint64_t get_microseconds64()
 
    clock_gettime(CLOCK_MONOTONIC_RAW, &spec);
 
-   us = spec.tv_sec * 1000000;
+   us = spec.tv_sec * 1000000ULL;
    us += spec.tv_nsec / 1000;
 
    return us;


### PR DESCRIPTION
Was using a 32 bit calculation when should have been 64bit.