### PR TITLE
2 makefiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ EGL, mmal, GLESv2, vcos, openmaxil, vchiq_arm, bcm_host, WFC, OpenVG.
 Use buildme to build. It requires cmake to be installed and an arm cross compiler. It is set up to use this one:
 https://github.com/raspberrypi/tools/tree/master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian
 
-Note that this repository does not contain the source for the edid_parser and vcdbg binaries due to licensing restrictions.
+Note that this repository does not contain the source for the edidparser and vcdbg binaries due to licensing restrictions.

--- a/interface/vmcs_host/linux/vcfiled/CMakeLists.txt
+++ b/interface/vmcs_host/linux/vcfiled/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file (etc/init.d/vcfiled ${PROJECT_BINARY_DIR}/etc/init.d/vcfiled)
 
 # script to start up vcfiled at start of day
 install(PROGRAMS ${PROJECT_BINARY_DIR}/etc/init.d/vcfiled
-        DESTINATION /etc/init.d)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/etc/init.d)
 # install locally to the installation directory too
 install(PROGRAMS ${PROJECT_BINARY_DIR}/etc/init.d/vcfiled
         DESTINATION ${VMCS_INSTALL_PREFIX}/share/install)


### PR DESCRIPTION
@6by9 
Sorry for the errors, & thank you for tidying it up.

BTW, I have simple omx-il  PCM-file-to-render audio (as opposed to the sine wave table in hello_audio) working, & am wondering if I can somehow "wrap" it to test in mmalplay? I'd need to mux a h264  with pcm audio in a suitable container so would make for a biggish file, but at least it'd let me see a path for audio to work in mmalplay. I realise you're busy, but any pointers would be very helpful. Oddly my omx-il version doesn't have the irritating buzz that's present in the hello_audio.bin example. I don't remember the buzz being there a couple of years ago, strange.