### PR TITLE
Makefiles for mmalcam and mmalplay

### DIFF
--- a/host_applications/vmcs/test_apps/mmalcam/Makefile
+++ b/host_applications/vmcs/test_apps/mmalcam/Makefile
@@ -1,0 +1,2 @@
+all:
+	gcc -O3  viewfinder.c mmalcam.c -o mmalcam -lmmal -lmmal_core  -lmmal_util  -I/opt/vc/include/  -L/opt/vc/lib/ -lpthread -lvcos

--- a/host_applications/vmcs/test_apps/mmalplay/Makefile
+++ b/host_applications/vmcs/test_apps/mmalplay/Makefile
@@ -1,0 +1,2 @@
+all:
+	gcc -O3  mmalplay.c playback.c -o mmalplay -lmmal -lmmal_core  -lmmal_util  -I/opt/vc/include/  -L/opt/vc/lib/ -lpthread -lvcos


### PR DESCRIPTION
Supercedes #536 as @tvjon is finding his way with git/github.

Minor update over the original in the output file for mmalcam has been amended to be ```mmalcam``` instead of ```mmalplay```