### PR TITLE
buildme: Add option for ARM64 builds via either native or cross compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ This repository contains the source code for the ARM side libraries used on Rasp
 These typically are installed in /opt/vc/lib and includes source for the ARM side code to interface to:
 EGL, mmal, GLESv2, vcos, openmaxil, vchiq_arm, bcm_host, WFC, OpenVG.
 
-Use buildme to build. It requires cmake to be installed and an arm cross compiler. It is set up to use this one:
+Use buildme to build. It requires cmake to be installed and an arm cross compiler. For 32 bit cross compiliation it is set up to use this one:
 https://github.com/raspberrypi/tools/tree/master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian
+
+Whilst 64 bit userspace is not officially supported, some of the libraries will work for it. To cross compile, install gcc-aarch64-linux-gnu and g++-aarch64-linux-gnu first. For both native and cross compiles, add the option ```--aarch64``` to the buildme command.
 
 Note that this repository does not contain the source for the edidparser and vcdbg binaries due to licensing restrictions.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ This repository contains the source code for the ARM side libraries used on Rasp
 These typically are installed in /opt/vc/lib and includes source for the ARM side code to interface to:
 EGL, mmal, GLESv2, vcos, openmaxil, vchiq_arm, bcm_host, WFC, OpenVG.
 
-Use buildme to build. It requires cmake to be installed and an arm cross compiler. For 32 bit cross compiliation it is set up to use this one:
+Use buildme to build. It requires cmake to be installed and an arm cross compiler. For 32-bit cross compiliation it is set up to use this one:
 https://github.com/raspberrypi/tools/tree/master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian
 
-Whilst 64 bit userspace is not officially supported, some of the libraries will work for it. To cross compile, install gcc-aarch64-linux-gnu and g++-aarch64-linux-gnu first. For both native and cross compiles, add the option ```--aarch64``` to the buildme command.
+Whilst 64-bit userspace is not officially supported, some of the libraries will work for it. To cross compile, install gcc-aarch64-linux-gnu and g++-aarch64-linux-gnu first. For both native and cross compiles, add the option ```--aarch64``` to the buildme command.
 
 Note that this repository does not contain the source for the edidparser and vcdbg binaries due to licensing restrictions.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repository contains the source code for the ARM side libraries used on Rasp
 These typically are installed in /opt/vc/lib and includes source for the ARM side code to interface to:
 EGL, mmal, GLESv2, vcos, openmaxil, vchiq_arm, bcm_host, WFC, OpenVG.
 
-Use buildme to build. It requires cmake to be installed and an arm cross compiler. For 32-bit cross compiliation it is set up to use this one:
+Use buildme to build. It requires cmake to be installed and an ARM cross compiler. For 32-bit cross compilation it is set up to use this one:
 https://github.com/raspberrypi/tools/tree/master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian
 
 Whilst 64-bit userspace is not officially supported, some of the libraries will work for it. To cross compile, install gcc-aarch64-linux-gnu and g++-aarch64-linux-gnu first. For both native and cross compiles, add the option ```--aarch64``` to the buildme command.

--- a/buildme
+++ b/buildme
@@ -9,7 +9,7 @@ if [ "$1" = "--debug" ]; then
 	shift
 fi
 
-if [ "$1" = "--arm64" ]; then
+if [ "$1" = "--aarch64" ]; then
 	ARM64=ON
 	CMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/aarch64-linux-gnu.cmake
 	shift

--- a/buildme
+++ b/buildme
@@ -1,19 +1,28 @@
 #!/bin/bash
 BUILDTYPE=Release
+ARCH=`arch`
+ARM64=OFF
+CMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake
 
 if [ "$1" = "--debug" ]; then
 	BUILDTYPE=Debug
 	shift
 fi
 
+if [ "$1" = "--arm64" ]; then
+	ARM64=ON
+	CMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/aarch64-linux-gnu.cmake
+	shift
+fi
+
 BUILDSUBDIR=`echo $BUILDTYPE | tr '[A-Z]' '[a-z]'`;
 
-if [ "armv6l" = `arch` ] || [ "armv7l" = `arch` ]; then
+if [ $ARCH = "armv6l" ] || [ $ARCH = "armv7l" ] || [ $ARCH = "aarch64" ]; then
 	# Native compile on the Raspberry Pi
 	mkdir -p build/raspberry/$BUILDSUBDIR
 	pushd build/raspberry/$BUILDSUBDIR
-	cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE ../../..
-	if [ "armv6l" = `arch` ]; then
+	cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE -DARM64=$ARM64 ../../..
+	if [ $ARCH = "armv6l" ]; then
 		make
 	else
 		make -j4
@@ -34,7 +43,7 @@ else
 	# Cross compile on a more capable machine
 	mkdir -p build/arm-linux/$BUILDSUBDIR
 	pushd build/arm-linux/$BUILDSUBDIR
-	cmake -DCMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake -DCMAKE_BUILD_TYPE=$BUILDTYPE ../../..
+	cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE -DCMAKE_BUILD_TYPE=$BUILDTYPE -DARM64=$ARM64 ../../..
 	make -j `nproc`
 
 	if [ "$1" != "" ]; then

--- a/makefiles/cmake/toolchains/aarch64-linux-gnu.cmake
+++ b/makefiles/cmake/toolchains/aarch64-linux-gnu.cmake
@@ -1,0 +1,22 @@
+
+#
+# CMake defines to cross-compile to ARM/Linux on BCM2708 using glibc.
+#
+
+SET(CMAKE_SYSTEM_NAME Linux)
+SET(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+SET(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+SET(CMAKE_ASM_COMPILER aarch64-linux-gnu-gcc)
+SET(CMAKE_SYSTEM_PROCESSOR arm)
+
+#ADD_DEFINITIONS("-march=armv6")
+#add_definitions("-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -marm")
+
+# rdynamic means the backtrace should work
+IF (CMAKE_BUILD_TYPE MATCHES "Debug")
+   add_definitions(-rdynamic)
+ENDIF()
+
+# avoids annoying and pointless warnings from gcc
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE")
+SET(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -c")


### PR DESCRIPTION
Supports native builds on aarch64 machines.

Supports making a 64bit build via either cross compiling, or on
aarch64 machines.
Both options require the addition of --arm64 to the command line,
otherwise 32bit libraries will be built.

Cross compiling requires the aarch64-linux-gnu- compile tools to
be installed (packages gcc-5-aarch64-linux-gnu and g++-aarch64-linux-gnu
on Ubuntu).