### PR TITLE
debug_sym: Remove annoying message should fb copy fail

### DIFF
--- a/host_applications/linux/libs/debug_sym/debug_sym.c
+++ b/host_applications/linux/libs/debug_sym/debug_sym.c
@@ -165,8 +165,6 @@ static int vc_mem_copy(void *dst, uint32_t src, uint32_t length)
 
     if ( ioctl( memFd, FBIODMACOPY, &ioparam ) != 0 )
     {
-        ERR( "Failed to get memory size via ioctl: %s(%d)\n",
-            strerror( errno ), errno );
         close( memFd );
         return -errno;
     }


### PR DESCRIPTION
Any kernel not using bcm2708_fb as the FB driver is likely to
fail the FBIODMACOPY ioctl that vcdbg tries to use to access
the hidden 16MB of RAM behind the peripheral space.
Remove the error message as it drops back to using /dev/mem
instead anyway.

Cherry-pick of 21a576f9f74df33f233b18717d225867c912e818 from the firmware tree as that appears not to have happened automagically.