### PR TITLE
Fix for missing timestamps when data exceed one buffers worth

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1378,21 +1378,18 @@ static void encoder_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
                bytes_written = fwrite(buffer->data, 1, buffer->length, pData->file_handle);
                if(pData->flush_buffers) fflush(pData->file_handle);
 
-               if(pData->pstate->save_pts &&
-                     (buffer->flags & MMAL_BUFFER_HEADER_FLAG_FRAME_END ||
-                      buffer->flags == 0 ||
-                      buffer->flags & MMAL_BUFFER_HEADER_FLAG_KEYFRAME) &&
-                     !(buffer->flags & MMAL_BUFFER_HEADER_FLAG_CONFIG))
+               if (pData->pstate->save_pts &&
+                  !(buffer->flags & MMAL_BUFFER_HEADER_FLAG_CONFIG) &&
+                  buffer->pts != MMAL_TIME_UNKNOWN &&
+                  buffer->pts != pData->pstate->lasttime)
                {
-                  if(buffer->pts != MMAL_TIME_UNKNOWN && buffer->pts != pData->pstate->lasttime)
-                  {
-                     int64_t pts;
-                     if(pData->pstate->frame==0)pData->pstate->starttime=buffer->pts;
-                     pData->pstate->lasttime=buffer->pts;
-                     pts = buffer->pts - pData->pstate->starttime;
-                     fprintf(pData->pts_file_handle,"%lld.%03lld\n", pts/1000, pts%1000);
-                     pData->pstate->frame++;
-                  }
+                  int64_t pts;
+                  if (pData->pstate->frame == 0)
+                     pData->pstate->starttime = buffer->pts;
+                  pData->pstate->lasttime = buffer->pts;
+                  pts = buffer->pts - pData->pstate->starttime;
+                  fprintf(pData->pts_file_handle, "%lld.%03lld\n", pts/1000, pts%1000);
+                  pData->pstate->frame++;
                }
             }
 


### PR DESCRIPTION
Fix provided by DaveS.

The addition of a NAL flag appears to have broken timestamps with
large buffers. This simplifies the 'if' around timestamps and takes
the NAL change in to account.

Also fixed up some bad code formatting after the if statement. Yes, I know.