### PR TITLE
Add media flushing call on when writing bitstream

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1376,7 +1376,11 @@ static void encoder_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buf
             else
             {
                bytes_written = fwrite(buffer->data, 1, buffer->length, pData->file_handle);
-               if(pData->flush_buffers) fflush(pData->file_handle);
+               if(pData->flush_buffers)
+               {
+                   fflush(pData->file_handle);
+                   fdatasync(fileno(pData->file_handle));
+               }
 
                if (pData->pstate->save_pts &&
                   !(buffer->flags & MMAL_BUFFER_HEADER_FLAG_CONFIG) &&


### PR DESCRIPTION
Under certain circumstances, the Linux file system write behind caching
get so much data to write in one go that is causes frames to be dropped.
The current fflush is not sufficient as that only flushes the C library
caches, not the Linux filesystem caches.

This fix forces data to be written to media as soon as it arrives, using
fdatasync().

Note, currently it's conditional on the --flush  command line parameter.