### PR TITLE
Fix for missing cleanup step for hello_videocube and hello_teapot

### DIFF
--- a/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
+++ b/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
@@ -46,6 +46,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "triangle.h"
 #include <pthread.h>
 
+#include <signal.h>
+
 
 #define PATH "./"
 
@@ -94,6 +96,8 @@ static CUBE_STATE_T _state, *state=&_state;
 
 static void* eglImage = 0;
 static pthread_t thread1;
+
+extern int thread_run;
 
 
 /***********************************************************
@@ -416,6 +420,10 @@ static void init_textures(CUBE_STATE_T *state)
 static void exit_func(void)
 // Function to be passed to atexit().
 {
+	
+   thread_run = 0;
+   pthread_join(thread1, NULL);
+	
    if (eglImage != 0)
    {
       if (!eglDestroyImageKHR(state->display, (EGLImageKHR) eglImage))
@@ -435,12 +443,20 @@ static void exit_func(void)
    printf("\ncube closed\n");
 } // exit_func()
 
+void sig_handler(int signo) {
+	
+	terminate = 1;
+	
+}
+
 //==============================================================================
 
 int main ()
 {
    bcm_host_init();
    printf("Note: ensure you have sufficient gpu_mem configured\n");
+   
+   signal(SIGINT, sig_handler);
 
    // Clear application state
    memset( state, 0, sizeof( *state ) );

--- a/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
+++ b/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
@@ -444,9 +444,9 @@ static void exit_func(void)
 } // exit_func()
 
 void sig_handler(int signo) {
-	
-	terminate = 1;
-	
+
+   terminate = 1;
+
 }
 
 //==============================================================================

--- a/host_applications/linux/apps/hello_pi/hello_teapot/video.c
+++ b/host_applications/linux/apps/hello_pi/hello_teapot/video.c
@@ -226,9 +226,9 @@ void *video_decode_test(void* arg)
          }
          if(!data_len)
             break;
-            
-		 if (!thread_run)
-			break;
+
+         if(!thread_run)
+            break;
 
          buf->nFilledLen = data_len;
          data_len = 0;

--- a/host_applications/linux/apps/hello_pi/hello_teapot/video.c
+++ b/host_applications/linux/apps/hello_pi/hello_teapot/video.c
@@ -40,10 +40,11 @@ static COMPONENT_T* egl_render = NULL;
 
 static void* eglImage = 0;
 
-int thread_run;
+int thread_run = 0;
 
 void my_fill_buffer_done(void* data, COMPONENT_T* comp)
 {
+
    OMX_STATETYPE state;
 
    if (OMX_GetState(ILC_GET_HANDLE(egl_render), &state) != OMX_ErrorNone) {
@@ -70,12 +71,10 @@ void *video_decode_test(void* arg)
       printf("eglImage is null.\n");
       exit(1);
    }
-   
-   thread_run = 1;
 
-   OMX_ERRORTYPE omx_err;
    OMX_VIDEO_PARAM_PORTFORMATTYPE format;
    OMX_TIME_CONFIG_CLOCKSTATETYPE cstate;
+   OMX_ERRORTYPE omx_err;
    COMPONENT_T *video_decode = NULL, *video_scheduler = NULL, *clock = NULL;
    COMPONENT_T *list[5];
    TUNNEL_T tunnel[4];
@@ -83,6 +82,8 @@ void *video_decode_test(void* arg)
    FILE *in;
    int status = 0;
    unsigned int data_len = 0;
+
+   thread_run = 1;
 
    memset(list, 0, sizeof(list));
    memset(tunnel, 0, sizeof(tunnel));
@@ -269,47 +270,27 @@ void *video_decode_test(void* arg)
    ilclient_teardown_tunnels(tunnel);
 
    ilclient_state_transition(list, OMX_StateIdle);
-
+   
    /*
-    * Cleanup note: egl_render does not generate the event when the
-    * transition from Idle to Loaded state is completed, so we deviate
-    * from the usual scheme: we issue the transition request manually
-    * with OMX_SendCommand() (which does not wait) and immediately
-    * free the buffer.
-    * 
-    * Here we overwrite the position of egl_render OMX component in the list
-    * so ilclient_state_transition() will not make the transition to Loaded 
-    * for egl_render
+    * To cleanup egl_render, we need to first disable its output port, then
+    * free the output eglBuffer, and finally request the state transition
+    * from to Loaded.
     */
-   list[1] = list[3];
-   list[3] = NULL;
-   
-   ilclient_state_transition(list, OMX_StateLoaded);
-   
-   /*
-     Let's do the transition to Loaded state for the egl_render and
-     free the buffer
-   */
-   omx_err = OMX_SendCommand(ILC_GET_HANDLE(egl_render), OMX_CommandStateSet, OMX_StateLoaded, 0);
-   
-   if (omx_err != OMX_ErrorNone && omx_err != OMX_ErrorSameState)
-      printf("Could not do OMX_CommandStateSet to OMX_StateLoaded for egl_render, omx_err(0x%x)\n", omx_err);
-
-   omx_err = OMX_FreeBuffer(ILC_GET_HANDLE(egl_render), 221, eglBuffer);
+   omx_err = OMX_SendCommand(ILC_GET_HANDLE(egl_render), OMX_CommandPortDisable, 221, NULL);
    if (omx_err != OMX_ErrorNone)
-      printf("OMX_FreeBuffer failed, omx_err(0x%x)\n", omx_err);
+      printf("Failed OMX_SendCommand\n");
+   
+   omx_err = OMX_FreeBuffer(ILC_GET_HANDLE(egl_render), 221, eglBuffer);
+   if(omx_err != OMX_ErrorNone)
+      printf("OMX_FreeBuffer failed\n");
 
-   /*
-    * Put the egl_render back into the list for the proper components release
-    */
-   list[3] = egl_render;
+   ilclient_state_transition(list, OMX_StateLoaded);
    
    ilclient_cleanup_components(list);
 
    OMX_Deinit();
 
    ilclient_destroy(client);
-   
    return (void *)status;
 }
 

--- a/host_applications/linux/apps/hello_pi/hello_teapot/video.c
+++ b/host_applications/linux/apps/hello_pi/hello_teapot/video.c
@@ -44,20 +44,18 @@ int thread_run;
 
 void my_fill_buffer_done(void* data, COMPONENT_T* comp)
 {
-	
-  OMX_STATETYPE state;
-  
-  if (OMX_GetState(ILC_GET_HANDLE(egl_render), &state) != OMX_ErrorNone) {
-	  printf("OMX_FillThisBuffer failed while getting egl_render component state\n");
-	  return;
-  }	
-	
-  if (state != OMX_StateExecuting)
-	return;
-	
-  if (OMX_FillThisBuffer(ilclient_get_handle(egl_render), eglBuffer) != OMX_ErrorNone)
-      printf("OMX_FillThisBuffer failed in callback\n");
+   OMX_STATETYPE state;
 
+   if (OMX_GetState(ILC_GET_HANDLE(egl_render), &state) != OMX_ErrorNone) {
+      printf("OMX_FillThisBuffer failed while getting egl_render component state\n");
+      return;
+   }
+
+   if (state != OMX_StateExecuting)
+      return;
+
+   if (OMX_FillThisBuffer(ilclient_get_handle(egl_render), eglBuffer) != OMX_ErrorNone)
+      printf("OMX_FillThisBuffer failed in callback\n");
 }
 
 
@@ -295,12 +293,12 @@ void *video_decode_test(void* arg)
    omx_err = OMX_SendCommand(ILC_GET_HANDLE(egl_render), OMX_CommandStateSet, OMX_StateLoaded, 0);
    
    if (omx_err != OMX_ErrorNone && omx_err != OMX_ErrorSameState)
-        printf("Could not do OMX_CommandStateSet to OMX_StateLoaded for egl_render, omx_err(0x%x)\n", omx_err);
+      printf("Could not do OMX_CommandStateSet to OMX_StateLoaded for egl_render, omx_err(0x%x)\n", omx_err);
 
    omx_err = OMX_FreeBuffer(ILC_GET_HANDLE(egl_render), 221, eglBuffer);
    if (omx_err != OMX_ErrorNone)
-		printf("OMX_FreeBuffer failed, omx_err(0x%x)\n", omx_err);
-        
+      printf("OMX_FreeBuffer failed, omx_err(0x%x)\n", omx_err);
+
    /*
     * Put the egl_render back into the list for the proper components release
     */

--- a/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
+++ b/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
@@ -46,6 +46,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "triangle.h"
 #include <pthread.h>
 
+#include <signal.h>
+
 
 #define PATH "./"
 
@@ -55,7 +57,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef M_PI
    #define M_PI 3.141592654
 #endif
-  
+
+extern int thread_run;
 
 typedef struct
 {
@@ -432,6 +435,10 @@ static void init_textures(CUBE_STATE_T *state)
 static void exit_func(void)
 // Function to be passed to atexit().
 {
+	
+   thread_run = 0;
+   pthread_join(thread1, NULL);
+	
    if (eglImage != 0)
    {
       if (!eglDestroyImageKHR(state->display, (EGLImageKHR) eglImage))
@@ -451,6 +458,12 @@ static void exit_func(void)
    printf("\ncube closed\n");
 } // exit_func()
 
+void sig_handler(int signo) {
+	
+	terminate = 1;
+	
+}
+
 //==============================================================================
 
 int main ()
@@ -460,6 +473,8 @@ int main ()
 
    // Clear application state
    memset( state, 0, sizeof( *state ) );
+   
+   signal(SIGINT, sig_handler);
       
    // Start OGLES
    init_ogl(state);

--- a/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
+++ b/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
@@ -459,9 +459,9 @@ static void exit_func(void)
 } // exit_func()
 
 void sig_handler(int signo) {
-	
-	terminate = 1;
-	
+
+   terminate = 1;
+
 }
 
 //==============================================================================

--- a/host_applications/linux/apps/hello_pi/hello_videocube/video.c
+++ b/host_applications/linux/apps/hello_pi/hello_videocube/video.c
@@ -226,9 +226,9 @@ void *video_decode_test(void* arg)
          }
          if(!data_len)
             break;
-            
-		 if (!thread_run)
-			break;
+
+         if(!thread_run)
+            break;
 
          buf->nFilledLen = data_len;
          data_len = 0;

--- a/host_applications/linux/apps/hello_pi/hello_videocube/video.c
+++ b/host_applications/linux/apps/hello_pi/hello_videocube/video.c
@@ -40,10 +40,11 @@ static COMPONENT_T* egl_render = NULL;
 
 static void* eglImage = 0;
 
-int thread_run;
+int thread_run = 0;
 
 void my_fill_buffer_done(void* data, COMPONENT_T* comp)
 {
+
    OMX_STATETYPE state;
 
    if (OMX_GetState(ILC_GET_HANDLE(egl_render), &state) != OMX_ErrorNone) {
@@ -70,12 +71,10 @@ void *video_decode_test(void* arg)
       printf("eglImage is null.\n");
       exit(1);
    }
-   
-   thread_run = 1;
 
-   OMX_ERRORTYPE omx_err;
    OMX_VIDEO_PARAM_PORTFORMATTYPE format;
    OMX_TIME_CONFIG_CLOCKSTATETYPE cstate;
+   OMX_ERRORTYPE omx_err;
    COMPONENT_T *video_decode = NULL, *video_scheduler = NULL, *clock = NULL;
    COMPONENT_T *list[5];
    TUNNEL_T tunnel[4];
@@ -83,6 +82,8 @@ void *video_decode_test(void* arg)
    FILE *in;
    int status = 0;
    unsigned int data_len = 0;
+
+   thread_run = 1;
 
    memset(list, 0, sizeof(list));
    memset(tunnel, 0, sizeof(tunnel));
@@ -269,47 +270,27 @@ void *video_decode_test(void* arg)
    ilclient_teardown_tunnels(tunnel);
 
    ilclient_state_transition(list, OMX_StateIdle);
-
+   
    /*
-    * Cleanup note: egl_render does not generate the event when the
-    * transition from Idle to Loaded state is completed, so we deviate
-    * from the usual scheme: we issue the transition request manually
-    * with OMX_SendCommand() (which does not wait) and immediately
-    * free the buffer.
-    * 
-    * Here we overwrite the position of egl_render OMX component in the list
-    * so ilclient_state_transition() will not make the transition to Loaded 
-    * for egl_render
+    * To cleanup egl_render, we need to first disable its output port, then
+    * free the output eglBuffer, and finally request the state transition
+    * from to Loaded.
     */
-   list[1] = list[3];
-   list[3] = NULL;
-   
-   ilclient_state_transition(list, OMX_StateLoaded);
-   
-   /*
-     Let's do the transition to Loaded state for the egl_render and
-     free the buffer
-   */
-   omx_err = OMX_SendCommand(ILC_GET_HANDLE(egl_render), OMX_CommandStateSet, OMX_StateLoaded, 0);
-   
-   if (omx_err != OMX_ErrorNone && omx_err != OMX_ErrorSameState)
-      printf("Could not do OMX_CommandStateSet to OMX_StateLoaded for egl_render, omx_err(0x%x)\n", omx_err);
-
-   omx_err = OMX_FreeBuffer(ILC_GET_HANDLE(egl_render), 221, eglBuffer);
+   omx_err = OMX_SendCommand(ILC_GET_HANDLE(egl_render), OMX_CommandPortDisable, 221, NULL);
    if (omx_err != OMX_ErrorNone)
-      printf("OMX_FreeBuffer failed, omx_err(0x%x)\n", omx_err);
+      printf("Failed OMX_SendCommand\n");
+   
+   omx_err = OMX_FreeBuffer(ILC_GET_HANDLE(egl_render), 221, eglBuffer);
+   if(omx_err != OMX_ErrorNone)
+      printf("OMX_FreeBuffer failed\n");
 
-   /*
-    * Put the egl_render back into the list for the proper components release
-    */
-   list[3] = egl_render;
+   ilclient_state_transition(list, OMX_StateLoaded);
    
    ilclient_cleanup_components(list);
 
    OMX_Deinit();
 
    ilclient_destroy(client);
-   
    return (void *)status;
 }
 

--- a/host_applications/linux/apps/hello_pi/hello_videocube/video.c
+++ b/host_applications/linux/apps/hello_pi/hello_videocube/video.c
@@ -44,20 +44,18 @@ int thread_run;
 
 void my_fill_buffer_done(void* data, COMPONENT_T* comp)
 {
-	
-  OMX_STATETYPE state;
-  
-  if (OMX_GetState(ILC_GET_HANDLE(egl_render), &state) != OMX_ErrorNone) {
-	  printf("OMX_FillThisBuffer failed while getting egl_render component state\n");
-	  return;
-  }	
-	
-  if (state != OMX_StateExecuting)
-	return;
-	
-  if (OMX_FillThisBuffer(ilclient_get_handle(egl_render), eglBuffer) != OMX_ErrorNone)
-      printf("OMX_FillThisBuffer failed in callback\n");
+   OMX_STATETYPE state;
 
+   if (OMX_GetState(ILC_GET_HANDLE(egl_render), &state) != OMX_ErrorNone) {
+      printf("OMX_FillThisBuffer failed while getting egl_render component state\n");
+      return;
+   }
+
+   if (state != OMX_StateExecuting)
+      return;
+
+   if (OMX_FillThisBuffer(ilclient_get_handle(egl_render), eglBuffer) != OMX_ErrorNone)
+      printf("OMX_FillThisBuffer failed in callback\n");
 }
 
 
@@ -295,12 +293,12 @@ void *video_decode_test(void* arg)
    omx_err = OMX_SendCommand(ILC_GET_HANDLE(egl_render), OMX_CommandStateSet, OMX_StateLoaded, 0);
    
    if (omx_err != OMX_ErrorNone && omx_err != OMX_ErrorSameState)
-        printf("Could not do OMX_CommandStateSet to OMX_StateLoaded for egl_render, omx_err(0x%x)\n", omx_err);
+      printf("Could not do OMX_CommandStateSet to OMX_StateLoaded for egl_render, omx_err(0x%x)\n", omx_err);
 
    omx_err = OMX_FreeBuffer(ILC_GET_HANDLE(egl_render), 221, eglBuffer);
    if (omx_err != OMX_ErrorNone)
-		printf("OMX_FreeBuffer failed, omx_err(0x%x)\n", omx_err);
-        
+      printf("OMX_FreeBuffer failed, omx_err(0x%x)\n", omx_err);
+
    /*
     * Put the egl_render back into the list for the proper components release
     */


### PR DESCRIPTION
The cleanup step in hello_videocube and hello_teapot is never executed because some bits are missing.
This pull request adds intercepts SIGINT and issue the cleanup when the user pressed CTRL-C.
Also this fixes the egl_render freeze when the OMX_StateLoaded is requested and properly disposes the buffer obtained with OMX_UseEGLImage() call