### PR TITLE
vcgencmd: Increase buffer size and ensure strings are null terminated

### DIFF
--- a/host_applications/linux/apps/gencmd/gencmd.c
+++ b/host_applications/linux/apps/gencmd/gencmd.c
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <time.h>
 
 #include "interface/vmcs_host/vc_vchi_gencmd.h"
+#include "interface/vmcs_host/vc_gencmd_defs.h"
 
 void show_usage()
 {
@@ -91,7 +92,7 @@ int main( int argc, char **argv )
       }
 
       int i = 1;
-      char buffer[ 1024 ];
+      char buffer[ GENCMDSERVICE_MSGFIFO_SIZE ];
       size_t buffer_offset = 0;
       clock_t before=0, after=0;
       double time_diff;
@@ -128,6 +129,7 @@ int main( int argc, char **argv )
       {
          printf( "vc_gencmd_read_response returned %d\n", ret );
       }
+      buffer[ sizeof(buffer) - 1 ] = 0;
 
       if( show_time )
       {

--- a/interface/vmcs_host/vc_gencmd_defs.h
+++ b/interface/vmcs_host/vc_gencmd_defs.h
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define VC_GENCMD_DEFS_H
 
 //Format of reply message is error code followed by a string
-#define GENCMDSERVICE_MSGFIFO_SIZE 1024
+#define GENCMDSERVICE_MSGFIFO_SIZE (4096 - 4)
 
 #define VC_GENCMD_VER   1
 


### PR DESCRIPTION
The current maximum response size from the firmware is 4096. Increase
the client's buffer to match this.

Additionally, ensure that the buffer is null terminated, otherwise,
strlen could fail.