### PR TITLE
Fix confusing typo swapping _MAP and _ALLOC

### DIFF
--- a/host_applications/linux/libs/sm/user-vcsm.c
+++ b/host_applications/linux/libs/sm/user-vcsm.c
@@ -834,7 +834,7 @@ void vcsm_status( VCSM_STATUS_T status, int pid )
       case VCSM_STATUS_HOST_WALK_PID_MAP:
       {
          ioctl( vcsm_handle,
-                VMCS_SM_IOCTL_HOST_WALK_PID_ALLOC,
+                VMCS_SM_IOCTL_HOST_WALK_PID_MAP,
                 &walk );
       }
       break;
@@ -842,7 +842,7 @@ void vcsm_status( VCSM_STATUS_T status, int pid )
       case VCSM_STATUS_HOST_WALK_PID_ALLOC:
       {
          ioctl( vcsm_handle,
-                VMCS_SM_IOCTL_HOST_WALK_PID_MAP,
+                VMCS_SM_IOCTL_HOST_WALK_PID_ALLOC,
                 &walk );
       }
       break;


### PR DESCRIPTION
VMCS_SM_IOCTL_HOST_WALK_PID_ALLOC and VMCS_SM_IOCTL_HOST_WALK_PID_MAP had been swapped, causing vcsm_status to yield unexpected results.