### PR TITLE
vmcs_host/vcilcs: build only on 32 bit

### DIFF
--- a/interface/vmcs_host/CMakeLists.txt
+++ b/interface/vmcs_host/CMakeLists.txt
@@ -15,18 +15,22 @@ add_library(vchostif
 #            ${VMCS_TARGET}/vmcs_main.c
 #  vc_vchi_haud.c
 #add_library(bufman            vc_vchi_bufman.c            )
+set(INSTALL_TARGETS "vchostif")
 
-# OpenMAX/IL component service
-add_library(vcilcs
-            vcilcs.c vcilcs_in.c vcilcs_out.c vcilcs_common.c)
+if(NOT ARM64)
+	# OpenMAX/IL component service
+	add_library(vcilcs
+		    vcilcs.c vcilcs_in.c vcilcs_out.c vcilcs_common.c)
 
-# ILCS pulls in EGL for the ILCS/EGL surface API support
-target_link_libraries(vcilcs brcmEGL brcmGLESv2 khrn_client vchiq_arm vcos)
+	# ILCS pulls in EGL for the ILCS/EGL surface API support
+	target_link_libraries(vcilcs brcmEGL brcmGLESv2 khrn_client vchiq_arm vcos)
+	set(INSTALL_TARGETS "${INSTALL_TARGETS} vcilcs")
+endif()
 
 # vchostif needs ilcore as well (vmcs_main pulls it in)
 target_link_libraries(vchostif vchiq_arm vcos)
 
 #target_link_libraries(bufman WFC)
 
-install(TARGETS vchostif vcilcs DESTINATION lib)
+install(TARGETS ${INSTALL_TARGETS} DESTINATION lib)
 


### PR DESCRIPTION
vcilcs requries libbrcmEGL, libbrcmGLESv2 and libkhrn_client which have
only 32 bit versions currently, so disable it when building aarch64

Signed-off-by: Dagg Stompler <daggs@gmx.com>