### PR TITLE
Fixes "__bitwise redefined" compilation error

### DIFF
--- a/opensrc/helpers/libfdt/libfdt_env.h
+++ b/opensrc/helpers/libfdt/libfdt_env.h
@@ -55,13 +55,12 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <linux/types.h>
 
 #ifdef __CHECKER__
 #define __force __attribute__((force))
-#define __bitwise __attribute__((bitwise))
 #else
 #define __force
-#define __bitwise
 #endif
 
 typedef uint16_t __bitwise fdt16_t;


### PR DESCRIPTION
Fixes the following compilation error:
opensrc/helpers/libfdt/libfdt_env.h:64: error: "__bitwise" redefined [-Werror]
   64 | #define __bitwise
In file included from /usr/include/linux/stat.h:5,
                 from /usr/include/bits/statx.h:30,
                 from /usr/include/sys/stat.h:446,
                 from host_applications/linux/apps/dtoverlay/dtoverlay_main.c:33:
/usr/include/linux/types.h:22: note: this is the location of the previous definition

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>