### PR TITLE
vcdbg/debugsym: Add option to specify the file size.

### DIFF
--- a/host_applications/linux/libs/debug_sym/debug_sym.c
+++ b/host_applications/linux/libs/debug_sym/debug_sym.c
@@ -177,7 +177,7 @@ int OpenVideoCoreMemoryFile( const char *filename, VC_MEM_ACCESS_HANDLE_T *vcHan
     return OpenVideoCoreMemoryFileWithOffset( filename, vcHandlePtr, 0 );
 }
 
-int OpenVideoCoreMemoryFileWithOffset( const char *filename, VC_MEM_ACCESS_HANDLE_T *vcHandlePtr, size_t loadOffset )
+int OpenVideoCoreMemoryFileWithOffsetAndSize( const char *filename, VC_MEM_ACCESS_HANDLE_T *vcHandlePtr, size_t loadOffset, size_t loadSize )
 {
     int                     rc = 0;
     VC_MEM_ACCESS_HANDLE_T  newHandle;
@@ -202,15 +202,59 @@ int OpenVideoCoreMemoryFileWithOffset( const char *filename, VC_MEM_ACCESS_HANDL
 
     if ( filename == NULL )
     {
-        newHandle->use_vc_mem = 1;
         filename = "/dev/vc-mem";
+        newHandle->memFd = open( filename, O_RDWR | O_SYNC );
+
+        if ( newHandle->memFd >= 0 )
+        {
+            newHandle->use_vc_mem = 1;
+        }
+        else
+        {
+
+            if (!loadOffset && !loadSize)
+            {
+                //Search /proc/cmdline for the vc_mem base and size params
+                int cmdlineFd;
+
+                cmdlineFd = open( "/proc/cmdline", O_RDONLY );
+                if ( cmdlineFd >= 0 )
+                {
+                    char cmdline[1024];  //Should be sufficient for most use cases
+                    char *vc_mem_ptr = cmdline;
+                    size_t size;
+
+                    size = read(cmdlineFd, cmdline, sizeof(cmdline));
+
+                    while ( (vc_mem_ptr = strstr(vc_mem_ptr, "vc_mem.")) != NULL)
+                    {
+                        if ( !strncmp(&vc_mem_ptr[7], "mem_base=", 9) )
+                        {
+                            loadOffset = ( size_t )strtoul( &vc_mem_ptr[7+9], NULL, 0);
+                        }
+                        else if ( !strncmp(&vc_mem_ptr[7], "mem_size=", 9) )
+                        {
+                            loadSize = ( size_t )strtoul( &vc_mem_ptr[7+9], NULL, 0);
+                            DBG("loadSize %x\n", loadSize);
+                        }
+                        vc_mem_ptr++;
+                    }
+                    close( cmdlineFd );
+                }
+            }
+
+            // Try /dev/mem
+            filename = "/dev/mem";
+            newHandle->memFd = open( filename, O_RDWR | O_SYNC );
+        }
     }
     else
     {
         newHandle->use_vc_mem = 0;
+        newHandle->memFd = open( filename, O_RDONLY | O_SYNC );
     }
 
-    if (( newHandle->memFd = open( filename, ( newHandle->use_vc_mem ? O_RDWR : O_RDONLY ) | O_SYNC )) < 0 )
+    if ( newHandle->memFd < 0 )
     {
         ERR( "Unable to open '%s': %s(%d)\n", filename, strerror( errno ), errno );
         free(newHandle);
@@ -261,13 +305,20 @@ int OpenVideoCoreMemoryFileWithOffset( const char *filename, VC_MEM_ACCESS_HANDL
     }
     else
     {
-        off_t len = lseek( newHandle->memFd, 0, SEEK_END );
-        if ( len < 0 )
+        off_t len;
+        if (!loadSize)
         {
-            ERR( "Failed to seek to end of file: %s(%d)\n", strerror( errno ), errno );
-            free(newHandle);
-            return -errno;
+            len = lseek( newHandle->memFd, 0, SEEK_END );
+            if ( len < 0 )
+            {
+                ERR( "Failed to seek to end of file: %s(%d)\n", strerror( errno ), errno );
+                free(newHandle);
+                return -errno;
+            }
         }
+        else
+            len = loadSize;
+
         newHandle->vcMemPhys = 0;
         newHandle->vcMemSize = len;
         newHandle->vcMemBase = 0;
@@ -436,6 +487,11 @@ err_exit:
     free( newHandle );
 
     return rc;
+}
+
+int OpenVideoCoreMemoryFileWithOffset( const char *filename, VC_MEM_ACCESS_HANDLE_T *vcHandlePtr, size_t loadOffset)
+{
+    return OpenVideoCoreMemoryFileWithOffsetAndSize(filename, vcHandlePtr, loadOffset, 0);
 }
 
 /****************************************************************************

--- a/host_applications/linux/libs/debug_sym/debug_sym.c
+++ b/host_applications/linux/libs/debug_sym/debug_sym.c
@@ -211,8 +211,7 @@ int OpenVideoCoreMemoryFileWithOffsetAndSize( const char *filename, VC_MEM_ACCES
         }
         else
         {
-
-            if (!loadOffset && !loadSize)
+            if ( !loadOffset && !loadSize )
             {
                 //Search /proc/cmdline for the vc_mem base and size params
                 int cmdlineFd;
@@ -306,7 +305,7 @@ int OpenVideoCoreMemoryFileWithOffsetAndSize( const char *filename, VC_MEM_ACCES
     else
     {
         off_t len;
-        if (!loadSize)
+        if ( !loadSize )
         {
             len = lseek( newHandle->memFd, 0, SEEK_END );
             if ( len < 0 )
@@ -491,7 +490,7 @@ err_exit:
 
 int OpenVideoCoreMemoryFileWithOffset( const char *filename, VC_MEM_ACCESS_HANDLE_T *vcHandlePtr, size_t loadOffset)
 {
-    return OpenVideoCoreMemoryFileWithOffsetAndSize(filename, vcHandlePtr, loadOffset, 0);
+    return OpenVideoCoreMemoryFileWithOffsetAndSize( filename, vcHandlePtr, loadOffset, 0 );
 }
 
 /****************************************************************************

--- a/host_applications/linux/libs/debug_sym/debug_sym.h
+++ b/host_applications/linux/libs/debug_sym/debug_sym.h
@@ -85,6 +85,17 @@ int OpenVideoCoreMemoryFileWithOffset( const char *filename,
                                        size_t loadOffset );
 
 /*
+ * Get access to the videocore space from a file, explicitly giving the
+ * offset of the load address (the start of the VC binary) relative to the
+ * start of the file, and size of the file.
+ * This allows the use of /dev/mem (which doesn't allow lseek(SEEK_END))
+ */
+int OpenVideoCoreMemoryFileWithOffsetAndSize( const char *filename,
+                                              VC_MEM_ACCESS_HANDLE_T *vcHandlePtr,
+                                              size_t loadOffset,
+                                              size_t loadSize );
+
+/*
  * Returns the number of symbols which were detected.
  */
 unsigned NumVideoCoreSymbols( VC_MEM_ACCESS_HANDLE_T handle );


### PR DESCRIPTION
This allows the use of /dev/mem instead of /dev/vc-mem (ie it
should work on mainline kernel builds.
vcdbg needs the offset and size of memory to work.
The firmware should have inserted these into the kernel
command line as vc_mem.mem_base and vc_mem.mem_size, so libdebugsym
tries to extract those values from /proc/cmdline, or you can
provide them on the command line via -l and -s

(/dev/mem couldn't be used previously as libdebugsym tries to do
lseek(SEEK_END) to get the length, and that isn't supported by
/dev/mem).

This is a cherry-pick of the libdebugsym part of firmware commit e3f9163dc05fa95ceb341497cd65db6aac76b7a0.