### PR TITLE
raspicam: Adjust framerate limits on long exposures for stills port.

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -935,7 +935,7 @@ static MMAL_STATUS_T create_camera_component(RASPISTILL_STATE *state)
    if(state->camera_parameters.shutter_speed > 6000000)
    {
       MMAL_PARAMETER_FPS_RANGE_T fps_range = {{MMAL_PARAMETER_FPS_RANGE, sizeof(fps_range)},
-         { 50, 1000 }, {166, 1000}
+         { 5, 1000 }, {166, 1000}
       };
       mmal_port_parameter_set(still_port, &fps_range.hdr);
    }

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -710,7 +710,7 @@ static MMAL_STATUS_T create_camera_component(RASPISTILLYUV_STATE *state)
    if(state->camera_parameters.shutter_speed > 6000000)
    {
       MMAL_PARAMETER_FPS_RANGE_T fps_range = {{MMAL_PARAMETER_FPS_RANGE, sizeof(fps_range)},
-         { 50, 1000 }, {166, 1000}
+         { 5, 1000 }, {166, 1000}
       };
       mmal_port_parameter_set(still_port, &fps_range.hdr);
    }

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1651,7 +1651,7 @@ static MMAL_STATUS_T create_camera_component(RASPIVID_STATE *state)
    if(state->camera_parameters.shutter_speed > 6000000)
    {
       MMAL_PARAMETER_FPS_RANGE_T fps_range = {{MMAL_PARAMETER_FPS_RANGE, sizeof(fps_range)},
-         { 50, 1000 }, {166, 1000}
+         { 5, 1000 }, {166, 1000}
       };
       mmal_port_parameter_set(video_port, &fps_range.hdr);
    }

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -969,7 +969,7 @@ static MMAL_STATUS_T create_camera_component(RASPIVIDYUV_STATE *state)
    if(state->camera_parameters.shutter_speed > 6000000)
    {
       MMAL_PARAMETER_FPS_RANGE_T fps_range = {{MMAL_PARAMETER_FPS_RANGE, sizeof(fps_range)},
-         { 50, 1000 }, {166, 1000}
+         { 5, 1000 }, {166, 1000}
       };
       mmal_port_parameter_set(video_port, &fps_range.hdr);
    }


### PR DESCRIPTION
Need to reduce the min fps limit to 0.005 for 200s exposures
available in HQ cam.

commit 27db31a8a828c095cb3e35f65d731c7628c587d7 fixed this for the video
port, but we need to do the same for the stills port as well.