### PR TITLE
MMAL / video_render: Allow column stride to be set on column formats

### DIFF
--- a/interface/mmal/mmal_format.h
+++ b/interface/mmal/mmal_format.h
@@ -105,6 +105,10 @@ typedef union
  * The following flags describe properties of an elementary stream */
 /* @{ */
 #define MMAL_ES_FORMAT_FLAG_FRAMED       0x1 /**< The elementary stream will already be framed */
+#define MMAL_ES_FORMAT_FLAG_COL_FMTS_WIDTH_IS_COL_STRIDE 0x2 /**< For column formats we ideally want to pass in the
+                                             column stride. This hasn't been the past behaviour, so require a
+                                             new flag to be set should es->video.width be the column stride
+                                             (in lines) instead of an ignored width value. */
 /* @} */
 
 /** \name Undefined encoding value.


### PR DESCRIPTION
MMAL and video_render used not to allow the client to set the column
stride or the chroma offset.
format->es->video.width wasn't actually being used for anything as
mmal_encoding_width_to_stride returns 0 meaning the component has to
compute it.

Add an extra flag for format->flags (MMAL_ES_FORMAT_FLAG_COL_FMTS_WIDTH_IS_COL_STRIDE)
that treats format->es->video.width as the column stride instead of
being ignored.

video_render also used to ignore nSliceHeight (format->es->video.width)
on the column formats.
Adding support in setting that (via vc_image vpitch) means that you can
crop down a larger image with the chroma in a different place.
eg width=(col stride), height=2160, crop.width=1920, crop.height=1080
flags = MMAL_ES_FORMAT_FLAG_COL_FMTS_WIDTH_IS_COL_STRIDE
will display the top left 1080p image out of a 4k source image.