### PR TITLE
Fix RGBA -> ARGB ordering in vgfont

### DIFF
--- a/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h
+++ b/host_applications/linux/apps/hello_pi/libs/vgfont/vgfont.h
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define B_888_MASK      (0x000000FF)
 #define ALPHA_888_MASK  (0xFF000000)
 #define GRAPHICS_RGBA32( r, g, b, a ) GRAPHICS_RGBA888( r, g, b, a )
-#define GRAPHICS_RGBA888( r, g, b, a ) ( (((a) << (8+8+8)) & ALPHA_888_MASK) | (((b) << (8+8)) & R_888_MASK) | (((g) << 8) & G_888_MASK) | ((r) & B_888_MASK) )
+#define GRAPHICS_RGBA888( r, g, b, a ) ( (((a) << (8+8+8)) & ALPHA_888_MASK) | (((r) << (8+8)) & R_888_MASK) | (((g) << 8) & G_888_MASK) | ((b) & B_888_MASK) )
 #define GRAPHICS_TRANSPARENT_COLOUR 0x00000001UL
 
 //resource defs


### PR DESCRIPTION
This is to finally move the fix at https://github.com/raspberrypi/firmware/pull/985 to where it seems to belong to.
Fixes obvious issues: https://github.com/raspberrypi/userland/issues/193 and https://github.com/raspberrypi/linux/issues/2359
All credits to @bs444, I just couldn't see this open PR without attention on a trivial mistake anymore.

This will break all workarounds of users who swapped desired R and B to get the right result.

The alternative is to swap the function arguments, so all existing workaround stay intact, like suggested here: https://github.com/raspberrypi/userland/issues/193#issuecomment-236659580
However this does not really change anything then depending on where one get the usual order from, and RGB in this order is simply what one expects and matches the functions name as well. So IMO best is to at last use the order that was initially intended and document this clearly in changelog.