### PR TITLE
Fix a compiler warning

### DIFF
--- a/host_applications/linux/apps/tvservice/tvservice.c
+++ b/host_applications/linux/apps/tvservice/tvservice.c
@@ -545,7 +545,7 @@ static int dump_edid( int display_id, const char *filename )
    if (fp)
       fclose(fp);
    if(written) {
-      LOG_STD( "Written %d bytes to %s", written, filename);
+      LOG_STD( "Written %zu bytes to %s", written, filename);
    } else {
       LOG_STD( "Nothing written!");
    }


### PR DESCRIPTION
This fixes the warning `format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’}`