### PR TITLE
Fix cast warning on vcos_llthread_current

### DIFF
--- a/interface/vcos/pthreads/vcos_platform.h
+++ b/interface/vcos/pthreads/vcos_platform.h
@@ -447,7 +447,7 @@ void vcos_thread_attr_setautostart(VCOS_THREAD_ATTR_T *attrs, VCOS_UNSIGNED auto
 
 VCOS_INLINE_IMPL
 VCOS_LLTHREAD_T *vcos_llthread_current(void) {
-   return (VCOS_LLTHREAD_T *)pthread_self();
+   return (VCOS_LLTHREAD_T *)(uintptr_t)pthread_self();
 }
 
 VCOS_INLINE_IMPL


### PR DESCRIPTION
Current header generates warnings of the form "warning: cast from
function call of type ‘pthread_t’ {aka ‘long unsigned int’} to
non-matching type ‘VCOS_LLTHREAD_T *’ {aka ‘struct VCOS_LLTHREAD_T *’}
[-Wbad-function-cast]".  Fix that.