### PR TITLE
Make explicit that libfdt should be built static

### DIFF
--- a/opensrc/helpers/libfdt/CMakeLists.txt
+++ b/opensrc/helpers/libfdt/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(.)
 
-add_library(fdt
+add_library(fdt STATIC
             fdt.c 
             fdt_empty_tree.c
             fdt_ro.c


### PR DESCRIPTION
To avoid issues such as #333 , make explicit that libfdt should be built as static.
This will allow raspberrypi-userland to more easily integrate with distributions which automatically add  -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_STATIC_LIBS:BOOL=OFF to their CMake flags.