### PR TITLE
Prefer BCM2711 nomenclature over BCM2838

### DIFF
--- a/host_applications/linux/apps/hello_pi/hello_font/main.c
+++ b/host_applications/linux/apps/hello_pi/hello_font/main.c
@@ -99,7 +99,7 @@ int main(void)
    bcm_host_init();
    int s;
 
-   if (get_processor_id() == PROCESSOR_BCM2838)
+   if (get_processor_id() == PROCESSOR_BCM2711)
    {
       puts("This demo application is not available on the Pi4\n\n");
       exit(0);

--- a/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
+++ b/host_applications/linux/apps/hello_pi/hello_teapot/triangle.c
@@ -456,7 +456,7 @@ int main ()
 {
    bcm_host_init();
 
-   if (get_processor_id() == PROCESSOR_BCM2838)
+   if (get_processor_id() == PROCESSOR_BCM2711)
    {
       puts("This demo application is not available on the Pi4\n\n");
       exit(0);

--- a/host_applications/linux/apps/hello_pi/hello_tiger/main.c
+++ b/host_applications/linux/apps/hello_pi/hello_tiger/main.c
@@ -487,7 +487,7 @@ int main(void)
    uint32_t width, height;
    bcm_host_init();
 
-   if (get_processor_id() == PROCESSOR_BCM2838)
+   if (get_processor_id() == PROCESSOR_BCM2711)
    {
       puts("This demo application is not available on the Pi4\n\n");
       exit(0);

--- a/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c
+++ b/host_applications/linux/apps/hello_pi/hello_triangle/triangle.c
@@ -530,7 +530,7 @@ int main ()
 {
    bcm_host_init();
 
-   if (get_processor_id() == PROCESSOR_BCM2838)
+   if (get_processor_id() == PROCESSOR_BCM2711)
    {
       puts("This demo application is not available on the Pi4\n\n");
       exit(0);

--- a/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
+++ b/host_applications/linux/apps/hello_pi/hello_triangle2/triangle2.c
@@ -492,7 +492,7 @@ int main ()
    GLfloat cx, cy;
    bcm_host_init();
 
-   if (get_processor_id() == PROCESSOR_BCM2838)
+   if (get_processor_id() == PROCESSOR_BCM2711)
    {
       puts("This demo application is not available on the Pi4\n\n");
       exit(0);

--- a/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
+++ b/host_applications/linux/apps/hello_pi/hello_videocube/triangle.c
@@ -471,7 +471,7 @@ int main ()
 {
    bcm_host_init();
 
-   if (get_processor_id() == PROCESSOR_BCM2838)
+   if (get_processor_id() == PROCESSOR_BCM2711)
    {
       puts("This demo application is not available on the Pi4\n\n");
       exit(0);

--- a/host_applications/linux/apps/hello_pi/libs/revision/revision.h
+++ b/host_applications/linux/apps/hello_pi/libs/revision/revision.h
@@ -28,7 +28,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PROCESSOR_BCM2835 0
 #define PROCESSOR_BCM2836 1
 #define PROCESSOR_BCM2837 2
-#define PROCESSOR_BCM2838 3
+#define PROCESSOR_BCM2711 3
+#define PROCESSOR_BCM2838 3 // included for backwards-compatibility
 
 /* Returns the type of the Pi being used
 */

--- a/host_applications/linux/libs/bcm_host/include/bcm_host.h
+++ b/host_applications/linux/libs/bcm_host/include/bcm_host.h
@@ -93,7 +93,8 @@ extern int bcm_host_is_kms_active(void);
 #define BCM_HOST_PROCESSOR_BCM2835 0
 #define BCM_HOST_PROCESSOR_BCM2836 1
 #define BCM_HOST_PROCESSOR_BCM2837 2
-#define BCM_HOST_PROCESSOR_BCM2838 3
+#define BCM_HOST_PROCESSOR_BCM2711 3
+#define BCM_HOST_PROCESSOR_BCM2838 3 // included for backwards-compatibility
 
 extern int bcm_host_get_processor_id(void);
 


### PR DESCRIPTION
I think when this code was originally written we weren't sure whether we'd be referring to the chip as BCM2838 or BCM2711. But we seem to have firmly settled on BCM2711 by now :slightly_smiling_face: 