### PR TITLE
bcm_host: Recognise all Pi 4 variants, add BCM2711

### DIFF
--- a/host_applications/linux/libs/bcm_host/bcm_host.c
+++ b/host_applications/linux/libs/bcm_host/bcm_host.c
@@ -265,11 +265,11 @@ int bcm_host_get_model_type(void)
    return model_type;
 }
 
-/* Returns the type of the Pi being used
+/* Test if the host is a member of the Pi 4 family (4B, 400 and CM4)
 */
 int bcm_host_is_model_pi4(void)
 {
-   return bcm_host_get_model_type() == 0x11 ? 1 : 0;
+   return bcm_host_get_processor_id() == BCM_HOST_PROCESSOR_BCM2711;
 }
 
 /* returns the processor ID

--- a/host_applications/linux/libs/bcm_host/include/bcm_host.h
+++ b/host_applications/linux/libs/bcm_host/include/bcm_host.h
@@ -78,7 +78,7 @@ unsigned bcm_host_get_sdram_address(void);
 
 extern int bcm_host_get_model_type(void);
 
-/* Returns 1 if model is  Pi4
+/* Returns 1 if host belongs to the Pi4 family (4B, 400 and CM4)
 */
 extern int bcm_host_is_model_pi4(void);
 
@@ -95,7 +95,8 @@ extern int bcm_host_is_kms_active(void);
 #define BCM_HOST_PROCESSOR_BCM2835 0
 #define BCM_HOST_PROCESSOR_BCM2836 1
 #define BCM_HOST_PROCESSOR_BCM2837 2
-#define BCM_HOST_PROCESSOR_BCM2838 3
+#define BCM_HOST_PROCESSOR_BCM2838 3 /* Deprecated name */
+#define BCM_HOST_PROCESSOR_BCM2711 3
 
 extern int bcm_host_get_processor_id(void);
 


### PR DESCRIPTION
bcm_host_is_model_pi4 should be equivalent to a test that the processor
type is BCM2711, so implement it as such (having added BCM2711 as a
recognised processor type and deprecating the name BCM2838).

See: https://github.com/raspberrypi/userland/issues/695

Signed-off-by: Phil Elwell <phil@raspberrypi.com>