### PR TITLE
Move work dir to /run/dtoverlay

### DIFF
--- a/host_applications/linux/apps/dtoverlay/dtoverlay_main.c
+++ b/host_applications/linux/apps/dtoverlay/dtoverlay_main.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CFG_DIR_1 "/sys/kernel/config"
 #define CFG_DIR_2 "/config"
 #define DT_SUBDIR "/device-tree"
-#define WORK_DIR "/tmp/.dtoverlays"
+#define WORK_DIR "/run/dtoverlay"
 #define OVERLAY_SRC_SUBDIR "overlays"
 #define README_FILE "README"
 #define DT_OVERLAYS_SUBDIR "overlays"


### PR DESCRIPTION
Move the work dir from /tmp/.dtoverlays to /run/dtoverlay since /tmp is world-writable. This also removes the leading . (there is no reason to hide it from ls) and changes it to match the name of the executable.

Existing state in /tmp/.dtoverlays will be lost, but that is easily fixed with a reboot (which is probably not a huge issue for people loading/unloading dtoverlays at runtime).