### PR TITLE
raspicam: Check system is running legacy camera stack

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiHelpers.h
+++ b/host_applications/linux/apps/raspicam/RaspiHelpers.h
@@ -39,5 +39,6 @@ void default_signal_handler(int signal_number);
 int mmal_status_to_int(MMAL_STATUS_T status);
 void print_app_details(FILE *fd);
 uint64_t get_microseconds64();
+void check_camera_stack();
 
 #endif

--- a/host_applications/linux/apps/raspicam/RaspiStill.c
+++ b/host_applications/linux/apps/raspicam/RaspiStill.c
@@ -1647,6 +1647,8 @@ int main(int argc, const char **argv)
    MMAL_PORT_T *encoder_input_port = NULL;
    MMAL_PORT_T *encoder_output_port = NULL;
 
+   check_camera_stack();
+
    bcm_host_init();
 
    // Register our application with the logging system

--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -1066,6 +1066,8 @@ int main(int argc, const char **argv)
    MMAL_PORT_T *preview_input_port = NULL;
    FILE *output_file = NULL;
 
+   check_camera_stack();
+
    bcm_host_init();
 
    // Register our application with the logging system

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -2408,6 +2408,8 @@ int main(int argc, const char **argv)
    MMAL_PORT_T *splitter_output_port = NULL;
    MMAL_PORT_T *splitter_preview_port = NULL;
 
+   check_camera_stack();
+
    bcm_host_init();
 
    // Register our application with the logging system

--- a/host_applications/linux/apps/raspicam/RaspiVidYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiVidYUV.c
@@ -1239,6 +1239,8 @@ int main(int argc, const char **argv)
    MMAL_PORT_T *camera_still_port = NULL;
    MMAL_PORT_T *preview_input_port = NULL;
 
+   check_camera_stack();
+
    bcm_host_init();
 
    // Register our application with the logging system


### PR DESCRIPTION
If the system is obviously configured for libcamera (for example) by
dint of /dev/video0 being given over to "unicam", complain and abort
immediately. In all other circumstances maintain previous behaviour.

(There seemed to be no obvious place for common code so it is
duplicated. There's not much.)

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>