### PR TITLE
mmal: Hack to make mmal core register VideoCore components

### DIFF
--- a/interface/mmal/core/CMakeLists.txt
+++ b/interface/mmal/core/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library (mmal_core ${LIBRARY_TYPE}
    mmal_clock.c
 )
 
-target_link_libraries (mmal_core vcos)
+target_link_libraries (mmal_core vcos mmal_vc_client)
 
 install(TARGETS mmal_core DESTINATION lib)
 install(FILES

--- a/interface/mmal/core/mmal_component.c
+++ b/interface/mmal/core/mmal_component.c
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/mmal_core_private.h"
 #include "mmal_logging.h"
 
+#include "vc/mmal_vc_api.h"
+
 /* Minimum number of buffers that will be available on the control port */
 #define MMAL_CONTROL_PORT_BUFFERS_MIN 4
 
@@ -665,6 +667,12 @@ MMAL_STATUS_T mmal_component_action_unlock(MMAL_COMPONENT_T *component)
 static void mmal_core_init_once(void)
 {
    vcos_mutex_create(&mmal_core_lock, VCOS_FUNCTION);
+
+   /* Horrid hack as linkers are now setting --as-needed by default, so fail
+    * to see the requirement for mmal_vc_client as a library because the core
+    * never calls it.
+    */
+   mmal_register_component_videocore();
 }
 
 static void mmal_core_init(void)

--- a/interface/mmal/vc/mmal_vc_api.c
+++ b/interface/mmal/vc/mmal_vc_api.c
@@ -1508,7 +1508,11 @@ fail:
    return status;
 }
 
+/*
+ * Do NOT register as a constructor due to horrid hack where the core will register
+ * these components in case the linker has determined that they weren't needed.
 MMAL_CONSTRUCTOR(mmal_register_component_videocore);
+*/
 void mmal_register_component_videocore(void)
 {
    mmal_component_supplier_register(VIDEOCORE_PREFIX, mmal_vc_component_create);

--- a/interface/mmal/vc/mmal_vc_api.h
+++ b/interface/mmal/vc/mmal_vc_api.h
@@ -233,6 +233,7 @@ MMAL_STATUS_T mmal_vc_compact(MMAL_VC_COMPACT_MODE_T mode, uint32_t *duration);
  */
 MMAL_STATUS_T mmal_vc_lmk(uint32_t alloc_size);
 
+void mmal_register_component_videocore(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The default linker option with Bullseye appears to now set
as-needed, so as the core doesn't call into mmal_vc_client
it is viewed as unnecesary, missing that mmal_vc_client has
a constructor that registers functions with the core.

Move the registration of the component supplier to the core_init.
The linker is therefore satisfied that mmal_vc_client is used,
and actually links to it.

This allows Picamera to work again.

https://github.com/waveform80/picamera/issues/697

Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>