### PR TITLE
Install manual pages as per GNU Coding Standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ SET(PROJECT_VER_PATCH 0)
 SET(PROJECT_VER "${PROJECT_VER_MAJOR}.${PROJECT_VER_MINOR}.${PROJECT_VER_PATCH}")
 SET(PROJECT_APIVER "${PROJECT_VER}")
 
+include(GNUInstallDirs)
+
 if(ARM64)
    set(BUILD_MMAL FALSE)
    set(BUILD_MMAL_APPS FALSE)
@@ -125,7 +127,7 @@ if(PKG_CONFIG_FOUND)
 	foreach(PCFILE bcm_host.pc brcmegl.pc brcmglesv2.pc brcmvg.pc vcsm.pc mmal.pc)
 		configure_file("pkgconfig/${PCFILE}.in" "${PCFILE}" @ONLY)
 		install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/${PCFILE}"
-			DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+			DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 	endforeach()
 endif()
 # Remove cache entry, if one added by command line

--- a/containers/CMakeLists.txt
+++ b/containers/CMakeLists.txt
@@ -66,7 +66,7 @@ set(packetizers_SRCS ${packetizers_SRCS} ${SOURCE_DIR}/h264/avc1_packetizer.c)
 
 add_library(containers ${LIBRARY_TYPE} ${core_SRCS} ${io_SRCS} ${net_SRCS} ${packetizers_SRCS})
 target_link_libraries(containers vcos)
-install(TARGETS containers DESTINATION lib)
+install(TARGETS containers DESTINATION ${LIBDIR})
 
 set(container_readers)
 set(container_writers)

--- a/helpers/dtoverlay/CMakeLists.txt
+++ b/helpers/dtoverlay/CMakeLists.txt
@@ -22,4 +22,4 @@ add_library (dtovl ${SHARED}
 
 target_link_libraries(dtovl fdt)
 
-install (TARGETS dtovl DESTINATION lib)
+install (TARGETS dtovl DESTINATION ${LIBDIR})

--- a/host_applications/linux/apps/dtmerge/CMakeLists.txt
+++ b/host_applications/linux/apps/dtmerge/CMakeLists.txt
@@ -18,4 +18,4 @@ add_executable(dtmerge dtmerge.c)
 target_link_libraries(dtmerge dtovl)
 
 install(TARGETS dtmerge RUNTIME DESTINATION bin)
-install(FILES dtmerge.1 DESTINATION man/man1)
+install(FILES dtmerge.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)

--- a/host_applications/linux/apps/dtoverlay/CMakeLists.txt
+++ b/host_applications/linux/apps/dtoverlay/CMakeLists.txt
@@ -17,11 +17,11 @@ include_directories (
 add_executable(dtoverlay dtoverlay_main.c utils.c)
 target_link_libraries(dtoverlay dtovl)
 install(TARGETS dtoverlay RUNTIME DESTINATION bin)
-install(FILES dtoverlay.1 DESTINATION man/man1)
+install(FILES dtoverlay.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 add_custom_command(TARGET dtoverlay POST_BUILD COMMAND ln;-sf;dtoverlay;dtparam)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dtparam DESTINATION bin)
-install(FILES dtparam.1 DESTINATION man/man1)
+install(FILES dtparam.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 set(DTOVERLAY_SCRIPTS dtoverlay-pre dtoverlay-post)
 install(PROGRAMS ${DTOVERLAY_SCRIPTS} DESTINATION bin)

--- a/host_applications/linux/apps/gencmd/CMakeLists.txt
+++ b/host_applications/linux/apps/gencmd/CMakeLists.txt
@@ -17,4 +17,4 @@ include_directories( ../../../..
 add_executable(vcgencmd gencmd.c)
 target_link_libraries(vcgencmd vcos vchiq_arm vchostif)
 install(TARGETS vcgencmd RUNTIME DESTINATION bin)
-install(FILES vcgencmd.1 DESTINATION man/man1)
+install(FILES vcgencmd.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)

--- a/host_applications/linux/apps/raspicam/CMakeLists.txt
+++ b/host_applications/linux/apps/raspicam/CMakeLists.txt
@@ -67,5 +67,5 @@ target_link_libraries(raspivid   ${MMAL_LIBS} vcos bcm_host m)
 target_link_libraries(raspividyuv   ${MMAL_LIBS} vcos bcm_host m)
 
 install(TARGETS raspistill raspiyuv raspivid raspividyuv RUNTIME DESTINATION bin)
-install(FILES raspistill.1 raspiyuv.1 raspivid.1 raspividyuv.1 DESTINATION man/man1)
-install(FILES raspicam.7 DESTINATION man/man7)
+install(FILES raspistill.1 raspiyuv.1 raspivid.1 raspividyuv.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+install(FILES raspicam.7 DESTINATION ${CMAKE_INSTALL_MANDIR}/man7)

--- a/host_applications/linux/apps/tvservice/CMakeLists.txt
+++ b/host_applications/linux/apps/tvservice/CMakeLists.txt
@@ -4,4 +4,4 @@ target_link_libraries(tvservice vchostif bcm_host)
 
 install(TARGETS tvservice
         RUNTIME DESTINATION bin)
-install(FILES tvservice.1 DESTINATION man/man1)
+install(FILES tvservice.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)

--- a/host_applications/linux/apps/vcmailbox/CMakeLists.txt
+++ b/host_applications/linux/apps/vcmailbox/CMakeLists.txt
@@ -3,5 +3,5 @@ target_link_libraries(vcmailbox vchostif)
 
 install(TARGETS vcmailbox
         RUNTIME DESTINATION bin)
-install(FILES vcmailbox.1 DESTINATION man/man1)
-install(FILES vcmailbox.7 raspiotp.7 raspirev.7 DESTINATION man/man7)
+install(FILES vcmailbox.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+install(FILES vcmailbox.7 raspiotp.7 raspirev.7 DESTINATION ${CMAKE_INSTALL_MANDIR}/man7)

--- a/host_applications/linux/libs/bcm_host/CMakeLists.txt
+++ b/host_applications/linux/libs/bcm_host/CMakeLists.txt
@@ -19,5 +19,5 @@ add_library(bcm_host ${SHARED} bcm_host.c)
 
 target_link_libraries(bcm_host vcos vchostif)
 
-install(TARGETS bcm_host DESTINATION lib)
+install(TARGETS bcm_host DESTINATION ${LIBDIR})
 

--- a/host_applications/linux/libs/debug_sym/CMakeLists.txt
+++ b/host_applications/linux/libs/debug_sym/CMakeLists.txt
@@ -11,6 +11,6 @@ include_directories (
 add_library(debug_sym ${SHARED} debug_sym.c)
 add_library(debug_sym_static STATIC debug_sym.c)
 
-install(TARGETS debug_sym DESTINATION lib)
-install(TARGETS debug_sym_static DESTINATION lib)
+install(TARGETS debug_sym DESTINATION ${LIBDIR})
+install(TARGETS debug_sym_static DESTINATION ${LIBDIR})
 install(FILES debug_sym.h DESTINATION include/interface/debug_sym)

--- a/host_applications/linux/libs/sm/CMakeLists.txt
+++ b/host_applications/linux/libs/sm/CMakeLists.txt
@@ -14,5 +14,5 @@ add_library(vcsm ${SHARED} user-vcsm.c)
 
 target_link_libraries(vcsm vcos)
 
-install(TARGETS vcsm DESTINATION lib)
+install(TARGETS vcsm DESTINATION ${LIBDIR})
 install(FILES user-vcsm.h DESTINATION include/interface/vcsm)

--- a/interface/khronos/CMakeLists.txt
+++ b/interface/khronos/CMakeLists.txt
@@ -78,8 +78,8 @@ target_link_libraries(GLESv2 EGL khrn_client vcos)
 target_link_libraries(WFC EGL)
 target_link_libraries(OpenVG EGL)
 
-install(TARGETS EGL GLESv2 OpenVG WFC khrn_client DESTINATION lib)
-install(TARGETS EGL_static GLESv2_static khrn_static DESTINATION lib)
+install(TARGETS EGL GLESv2 OpenVG WFC khrn_client DESTINATION ${LIBDIR})
+install(TARGETS EGL_static GLESv2_static khrn_static DESTINATION ${LIBDIR})
 
 # recommended names to use to avoid conflicts with mesa libs
 add_library(brcmEGL ${SHARED} ${EGL_SOURCE})
@@ -92,4 +92,4 @@ target_link_libraries(brcmGLESv2 brcmEGL khrn_client vcos)
 target_link_libraries(brcmWFC brcmEGL)
 target_link_libraries(brcmOpenVG brcmEGL)
 
-install(TARGETS brcmEGL brcmGLESv2 brcmOpenVG brcmWFC DESTINATION lib)
+install(TARGETS brcmEGL brcmGLESv2 brcmOpenVG brcmWFC DESTINATION ${LIBDIR})

--- a/interface/mmal/CMakeLists.txt
+++ b/interface/mmal/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(client)
 
 target_link_libraries(mmal mmal_core mmal_util mmal_vc_client vcos mmal_components)
 
-install(TARGETS mmal DESTINATION lib)
+install(TARGETS mmal DESTINATION ${LIBDIR})
 install(FILES
    mmal.h
    mmal_buffer.h

--- a/interface/mmal/components/CMakeLists.txt
+++ b/interface/mmal/components/CMakeLists.txt
@@ -30,5 +30,5 @@ set(container_libs ${container_libs} containers)
 target_link_libraries(mmal_components ${container_libs} mmal_util)
 target_link_libraries(mmal_components mmal_core)
 
-install(TARGETS mmal_components DESTINATION lib)
+install(TARGETS mmal_components DESTINATION ${LIBDIR})
 

--- a/interface/mmal/core/CMakeLists.txt
+++ b/interface/mmal/core/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library (mmal_core ${LIBRARY_TYPE}
 
 target_link_libraries (mmal_core vcos mmal_vc_client)
 
-install(TARGETS mmal_core DESTINATION lib)
+install(TARGETS mmal_core DESTINATION ${LIBDIR})
 install(FILES
    mmal_buffer_private.h
    mmal_clock_private.h

--- a/interface/mmal/util/CMakeLists.txt
+++ b/interface/mmal/util/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library (mmal_util ${LIBRARY_TYPE}
 
 target_link_libraries (mmal_util vcos)
 
-install(TARGETS mmal_util DESTINATION lib)
+install(TARGETS mmal_util DESTINATION ${LIBDIR})
 install(FILES
    mmal_component_wrapper.h
    mmal_connection.h

--- a/interface/mmal/vc/CMakeLists.txt
+++ b/interface/mmal/vc/CMakeLists.txt
@@ -13,7 +13,7 @@ endif(BUILD_MMAL_APPS)
 
 include_directories ( ../../../host_applications/linux/libs/sm )
 
-install(TARGETS mmal_vc_client DESTINATION lib)
+install(TARGETS mmal_vc_client DESTINATION ${LIBDIR})
 install(FILES
    mmal_vc_api.h
    mmal_vc_api_drm.h

--- a/interface/vchiq_arm/CMakeLists.txt
+++ b/interface/vchiq_arm/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(vchiq_arm SHARED
 # pull in VCHI cond variable emulation
 target_link_libraries(vchiq_arm vcos)
 
-install(TARGETS vchiq_arm DESTINATION lib)
+install(TARGETS vchiq_arm DESTINATION ${LIBDIR})
 #install(FILES etc/10-vchiq.rules DESTINATION /etc/udev/rules.d)
 
 include_directories(../..)

--- a/interface/vcos/pthreads/CMakeLists.txt
+++ b/interface/vcos/pthreads/CMakeLists.txt
@@ -43,4 +43,4 @@ endif ()
 
 
 #install(FILES ${HEADERS} DESTINATION include)
-install(TARGETS vcos DESTINATION lib)
+install(TARGETS vcos DESTINATION ${LIBDIR})

--- a/interface/vmcs_host/CMakeLists.txt
+++ b/interface/vmcs_host/CMakeLists.txt
@@ -32,5 +32,5 @@ target_link_libraries(vchostif vchiq_arm vcos)
 
 #target_link_libraries(bufman WFC)
 
-install(TARGETS ${INSTALL_TARGETS} DESTINATION lib)
+install(TARGETS ${INSTALL_TARGETS} DESTINATION ${LIBDIR})
 

--- a/middleware/openmaxil/CMakeLists.txt
+++ b/middleware/openmaxil/CMakeLists.txt
@@ -49,4 +49,4 @@ else ()
 
 endif ()
 
-install (TARGETS openmaxil DESTINATION lib)
+install (TARGETS openmaxil DESTINATION ${LIBDIR})

--- a/pkgconfig/bcm_host.pc.in
+++ b/pkgconfig/bcm_host.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: bcm_host

--- a/pkgconfig/brcmegl.pc.in
+++ b/pkgconfig/brcmegl.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: brcmEGL

--- a/pkgconfig/brcmglesv2.pc.in
+++ b/pkgconfig/brcmglesv2.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: brcmGLESv2

--- a/pkgconfig/brcmvg.pc.in
+++ b/pkgconfig/brcmvg.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: brcmOpenVG

--- a/pkgconfig/mmal.pc.in
+++ b/pkgconfig/mmal.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: MMAL

--- a/pkgconfig/vcsm.pc.in
+++ b/pkgconfig/vcsm.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: VCSM


### PR DESCRIPTION
Install manual pages as per GNU Coding Standards
    
Includes GNUInstallDirs and uses MANDIR (instead of hardcoded man)
to install manual pages.
    
See: https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html

This patch depends on a similar #650 to be merged first.