### PR TITLE
raspivid:Turn off buffering on fwrite(3)

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1117,6 +1117,10 @@ static FILE *open_filename(RASPIVID_STATE *pState, char *filename)
 
          if (sfd >= 0)
             new_handle = fdopen(sfd, "w");
+            if (bcm_host_get_processor_id() == BCM_HOST_PROCESSOR_BCM2835)
+               // Turn off buffering
+               // BCM2835 provides a 128KB system L2 cache, which is used primarily by the GPU
+               setvbuf(new_handle, NULL, _IONBF, 0);
       }
       else
       {

--- a/host_applications/linux/apps/raspicam/RaspiVid.c
+++ b/host_applications/linux/apps/raspicam/RaspiVid.c
@@ -1116,11 +1116,11 @@ static FILE *open_filename(RASPIVID_STATE *pState, char *filename)
          }
 
          if (sfd >= 0)
+         {
             new_handle = fdopen(sfd, "w");
-            if (bcm_host_get_processor_id() == BCM_HOST_PROCESSOR_BCM2835)
-               // Turn off buffering
-               // BCM2835 provides a 128KB system L2 cache, which is used primarily by the GPU
-               setvbuf(new_handle, NULL, _IONBF, 0);
+            // Turn off buffering
+            setvbuf(new_handle, NULL, _IONBF, 0);
+         }
       }
       else
       {


### PR DESCRIPTION
This change makes low-latency udp streaming more stable in the BCM2835:Zero W environment.
(BCM2835 provides a 128KB system L2 cache, which is used primarily by the GPU)
 
+ script
```
./build/bin/raspivid -w 640 -h 360 -o udp://192.168.15.202:50002 -fps 30 --codec H264 -n -t 0
```