### PR TITLE
raspicam: Fix raspicommonsettings_parse_cmdline

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiCommonSettings.h
+++ b/host_applications/linux/apps/raspicam/RaspiCommonSettings.h
@@ -54,6 +54,6 @@ typedef struct
 void raspicommonsettings_set_defaults(RASPICOMMONSETTINGS_PARAMETERS *);
 void raspicommonsettings_dump_parameters(RASPICOMMONSETTINGS_PARAMETERS *);
 void raspicommonsettings_display_help();
-int raspicommonsettings_parse_cmdline(RASPICOMMONSETTINGS_PARAMETERS *state, const char *arg1, const char *arg2, void (*app_help)());
+int raspicommonsettings_parse_cmdline(RASPICOMMONSETTINGS_PARAMETERS *state, const char *arg1, const char *arg2, void (*app_help)(char*));
 
 #endif


### PR DESCRIPTION
Fix raspicommonsettings_parse_cmdline's definition to match declaration