### PR TITLE
Add bcm2712 as a platform and path string assignments

### DIFF
--- a/helpers/dtoverlay/dtoverlay.c
+++ b/helpers/dtoverlay/dtoverlay.c
@@ -220,6 +220,16 @@ int dtoverlay_find_node(DTBLOB_T *dtb, const char *node_path, int path_len)
    return fdt_path_offset_namelen(dtb->fdt, node_path, path_len);
 }
 
+int dtoverlay_first_subnode(DTBLOB_T *dtb, int node_off)
+{
+    return fdt_first_subnode(dtb->fdt, node_off);
+}
+
+int dtoverlay_next_subnode(DTBLOB_T *dtb, int subnode_off)
+{
+    return fdt_next_subnode(dtb->fdt, subnode_off);
+}
+
 // Returns 0 on success, otherwise <0 error code
 int dtoverlay_set_node_properties(DTBLOB_T *dtb, const char *node_path,
                                   DTOVERLAY_PARAM_T *properties,

--- a/helpers/dtoverlay/dtoverlay.c
+++ b/helpers/dtoverlay/dtoverlay.c
@@ -2559,6 +2559,11 @@ void dtoverlay_init_map_from_fp(FILE *fp, const char *compatible,
             platform_name = "bcm2711";
             break;
         }
+        else if (strncmp(p, "bcm2712", len) == 0)
+        {
+            platform_name = "bcm2712";
+            break;
+        }
 
         compatible_len -= (p - compatible);
         compatible = p;

--- a/helpers/dtoverlay/dtoverlay.h
+++ b/helpers/dtoverlay/dtoverlay.h
@@ -114,6 +114,10 @@ int dtoverlay_delete_node(DTBLOB_T *dtb, const char *node_name, int path_len);
 
 int dtoverlay_find_node(DTBLOB_T *dtb, const char *node_path, int path_len);
 
+
+int dtoverlay_first_subnode(DTBLOB_T *dtb, int node_off);
+int dtoverlay_next_subnode(DTBLOB_T *dtb, int subnode_off);
+
 int dtoverlay_set_node_properties(DTBLOB_T *dtb, const char *node_path,
                                   DTOVERLAY_PARAM_T *properties,
                                   unsigned int num_properties);


### PR DESCRIPTION
1. Literal path string assignments makes it possible to write things like:

    `console_uart0 = <&aliases>, "console=", &uart0;`

    and let the dtc compiler substitute the path to the node with the  `uart0` label. 

2. Add functions to iterate through subnodes.
3. Adding bcm2712 as a platform allows for Pi 5-specific overlay variants.


